### PR TITLE
Fix for off-by-one index in teardown

### DIFF
--- a/built/execs/teardown.js
+++ b/built/execs/teardown.js
@@ -16,7 +16,7 @@ const createTeardown = (Config, Logger) => {
     const dockerComposeDown = async () => {
         const timeout = 10;
         await execa_1.default.shell(`docker-compose down --volumes --rmi local --timeout ${timeout}`);
-        Logger.stop('docker-compose down ran successfully');
+        Logger.stop('docker-compose: success');
     };
     const tearAll = async () => {
         Logger.loading('Teardown started');
@@ -27,12 +27,12 @@ const createTeardown = (Config, Logger) => {
         ];
         const containerIdsLen = containerIds.length;
         for (let i = 0; containerIdsLen > i; i++) {
-            const progress = `${i}/${containerIdsLen}`;
+            const progress = `${i + 1}/${containerIdsLen}`;
             const containerId = containerIds[i];
             await stopContainerById(containerId, progress);
             await removeContainerById(containerId, progress);
-            // await dockerComposeDown(progress) // TODO: Read up on this
         }
+        await dockerComposeDown(); // TODO: Read up on this
         Logger.success('Teardown successful');
     };
     return {

--- a/src/execs/teardown.ts
+++ b/src/execs/teardown.ts
@@ -33,10 +33,10 @@ const createTeardown = (Config: DockestConfig, Logger: DockestLogger): ITeardown
   }
 
   const dockerComposeDown: dockerComposeDown = async () => {
-    const timeout = 10
+    const timeout = 15
     await execa.shell(`docker-compose down --volumes --rmi local --timeout ${timeout}`)
 
-    Logger.stop('docker-compose down ran successfully')
+    Logger.stop('docker-compose: success')
   }
 
   const tearAll: tearAll = async () => {
@@ -60,13 +60,14 @@ const createTeardown = (Config: DockestConfig, Logger: DockestLogger): ITeardown
 
     const containerIdsLen = containerIds.length
     for (let i = 0; containerIdsLen > i; i++) {
-      const progress = `${i}/${containerIdsLen}`
+      const progress = `${i + 1}/${containerIdsLen}`
       const containerId = containerIds[i]
 
       await stopContainerById(containerId, progress)
       await removeContainerById(containerId, progress)
-      // await dockerComposeDown(progress) // TODO: Read up on this
     }
+
+    await dockerComposeDown() // TODO: Read up on this
 
     Logger.success('Teardown successful')
   }


### PR DESCRIPTION
Teardown was printing index, which starts at 0. For readability it makes more sense starting from 1.