### PR TITLE
fix: ts error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 script:
   # run linting
   - yarn lint
+  - yarn build
 
   # generate typedoc markdown files
   - yarn generate:typedoc

--- a/src/utils/teardownSingle.spec.ts
+++ b/src/utils/teardownSingle.spec.ts
@@ -33,7 +33,7 @@ describe('teardownSingle', () => {
         throw error
       })
 
-      const result = await teardownSingle(generalPurposeRunner)
+      await teardownSingle(generalPurposeRunner)
 
       expect(generalPurposeRunner.logger.info).toMatchSnapshot()
       expect(generalPurposeRunner.logger.error).toMatchSnapshot()


### PR DESCRIPTION
`yarn build` fails

```
laurin@Laurins-MacBook-Pro:~/projects/dockest$ yarn build
yarn run v1.17.3
$ rm -rf ./dist && tsc
src/utils/teardownSingle.spec.ts:36:13 - error TS6133: 'result' is declared but its value is never read.

36       const result = await teardownSingle(generalPurposeRunner)
               ~~~~~~


Found 1 error.

error Command failed with exit code 2.
```