### PR TITLE
feat(GeneralPurposeRunner): allow declaring a responsiveness check via constructor config

### DIFF
--- a/docs/responsiveness.md
+++ b/docs/responsiveness.md
@@ -4,6 +4,10 @@ title: Responsiveness
 sidebar_label: Responsiveness
 ---
 
-Recursively attempts to determine the responsiveness of the Docker service by calling internal APIs of the service. For example a database would be called with a trivial `SELECT` query.
+The responsiveness healthcheck is used for determining when a container is ready. E.g. when the Database is ready or the HTTP server has started.
 
-The responsiveness healthcheck will fail once the responsivenessTimeout is reached.
+The standard runners (Redis, Postgres, ZooKeeper, Kafka) already have a healthcheck implemented. E.g. the PostgresRunner tries to run a trivial `SELECT` query.
+
+The responsiveness healthcheck will run until it succeeds or fail once the responsivenessTimeout is reached.
+
+In case you are using the GeneralPurposeRunner you can implement your own responsiveness check via the [`getResponsivenessCheckCommand` config option](runner_generalpurposerunner.md).

--- a/docs/runner_generalpurposerunner.md
+++ b/docs/runner_generalpurposerunner.md
@@ -1,0 +1,62 @@
+---
+id: runner_generalpurposerunner
+title: GeneralPurposeRunner
+sidebar_label: GeneralPurposeRunner
+---
+
+## Minimal working example
+
+```TypeScript
+import { runners } from "dockest"
+
+const opts = {
+  service: 'service-name',
+  image: "your-application-image",
+  dependsOn: [
+    postgresRunner
+  ],
+  ports: { '3000': '3000' },
+  networks: ["database_network"],
+  getResponsivenessCheckCommand: containerId => {
+    return ` \
+      docker exec ${containerId} \
+      sh -c "wget --quiet --tries=1 --spider http://localhost:3000/.well-known/healthcheck" \
+    `;
+  }
+}
+
+const appRunner = new runners.GeneralPurposeRunner(opts)
+```
+
+## Interface
+
+| Prop                          | Required | Type                            | Default            | Description                                                                                                                                                                                              |
+| ----------------------------- | -------- | ------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| service                       | true     | string                          | -                  | Used as an identifier of the container in the stack                                                                                                                                                      |
+| dependsOn                     | true     | Runner[]                        | []                 | Defines the service's [dependencies](https://docs.docker.com/compose/compose-file/#depends_on)                                                                                                           |
+| commands                      | false    | string[]                        | []                 | Custom commands that execute _once_ after service responsiveness has been established                                                                                                                    |
+| connectionTimeout             | false    | number                          | 30                 | How long to wait for the resource to be reachable                                                                                                                                                        |
+| image                         | false    | string                          | undefined          | Specify the [image](https://docs.docker.com/compose/compose-file/#image) to start the container from                                                                                                     |
+| ports                         | false    | { [key: string]: string }       | { '9092': '9092' } | [{ hostPort: containerPort }](https://docs.docker.com/compose/compose-file/#short-syntax-1)                                                                                                              |
+| networks                      | false    | string[]                        | []                 | Networks used for determining which containers can communicate between each other through the service name as a host ([Learn more](https://docs.docker.com/compose/networking/#specify-custom-networks)) |
+| getResponsivenessCheckCommand | null     | (containerId: string) => string | null               | Declare a function that returns a responsiveness check command                                                                                                                                           |
+
+## Declaring a Responsiveness Check Command
+
+The responsiveness healthcheck is used for determining when a container is ready. E.g. when the HTTP server has started.
+
+A responsiveness check cn be declared via the `getResponsivenessCheckCommand` option.
+
+```TypeScript
+const getResponsivenessCheckCommand = (containerId: string) => {
+  return ` \
+    docker exec ${containerId} \
+    sh -c "wget --quiet --tries=1 --spider http://localhost:3000/.well-known/healthcheck" \
+  `;
+}
+
+const appRunner = new runners.GeneralPurposeRunner({
+  ...opts,
+  getResponsivenessCheckCommand
+})
+```

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -23,6 +23,7 @@ Dockest {
     "runners": Array [
       GeneralPurposeRunner {
         "containerId": "",
+        "createResponsivenessCheckCmd": null,
         "getComposeService": [Function],
         "initializer": "",
         "logger": Logger {

--- a/src/runners/GeneralPurposeRunner/__snapshots__/index.spec.ts.snap
+++ b/src/runners/GeneralPurposeRunner/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`GeneralPurposeRunner should create unique instances 1`] = `
 GeneralPurposeRunner {
   "containerId": "",
+  "createResponsivenessCheckCmd": null,
   "getComposeService": [Function],
   "initializer": "",
   "logger": Logger {
@@ -33,6 +34,7 @@ GeneralPurposeRunner {
 exports[`GeneralPurposeRunner should create unique instances 2`] = `
 GeneralPurposeRunner {
   "containerId": "",
+  "createResponsivenessCheckCmd": null,
   "getComposeService": [Function],
   "initializer": "",
   "logger": Logger {

--- a/src/runners/GeneralPurposeRunner/index.ts
+++ b/src/runners/GeneralPurposeRunner/index.ts
@@ -6,8 +6,14 @@ import { SHARED_DEFAULT_CONFIG_PROPS } from '../constants'
 import { defaultGetComposeService } from '../composeFileHelper'
 
 interface RequiredConfigProps extends SharedRequiredConfigProps {}
+interface OptionalConfigProps {
+  getResponsivenessCheckCommand: (containerId: string) => string
+}
 interface DefaultableConfigProps extends SharedDefaultableConfigProps {}
-interface GeneralPurposeRunnerConfig extends RequiredConfigProps, DefaultableConfigProps {}
+interface GeneralPurposeRunnerConfig
+  extends RequiredConfigProps,
+    Partial<OptionalConfigProps>,
+    DefaultableConfigProps {}
 
 const DEFAULT_CONFIG: DefaultableConfigProps = {
   ...SHARED_DEFAULT_CONFIG_PROPS,
@@ -18,11 +24,22 @@ class GeneralPurposeRunner implements BaseRunner {
   public initializer = ''
   public runnerConfig: GeneralPurposeRunnerConfig
   public logger: Logger
+  public createResponsivenessCheckCmd: (() => string) | null = null
 
-  public constructor(config: RequiredConfigProps & Partial<DefaultableConfigProps>) {
+  public constructor(config: RequiredConfigProps & Partial<DefaultableConfigProps> & Partial<OptionalConfigProps>) {
     this.runnerConfig = {
       ...DEFAULT_CONFIG,
       ...config,
+    }
+
+    if (this.runnerConfig.getResponsivenessCheckCommand) {
+      this.createResponsivenessCheckCmd = () => {
+        if (!this.runnerConfig.getResponsivenessCheckCommand) {
+          throw new Error('Invalid state')
+        }
+        const command = this.runnerConfig.getResponsivenessCheckCommand(this.containerId)
+        return command
+      }
     }
 
     this.logger = new Logger(this)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,32 +1,19 @@
 {
   "docs": {
-    "Getting started": [
-      "introduction",
-      "example"
-    ],
+    "Getting started": ["introduction", "example"],
     "Interfaces": [
       "dockest_constructor",
       "jest",
       {
         "type": "subcategory",
         "label": "Runners",
-        "ids": [
-          "runner_redis",
-          "runner_postgres",
-          "runner_zookeeper",
-          "runner_kafka"
-        ]
+        "ids": ["runner_redis", "runner_postgres", "runner_zookeeper", "runner_kafka", "runner_generalpurposerunner"]
       }
     ],
-    "Healthchecks": [
-      "connectivity",
-      "responsiveness"
-    ]
+    "Healthchecks": ["connectivity", "responsiveness"]
   },
   "dockest": {
-    "Introduction": [
-      "typedoc/index"
-    ],
+    "Introduction": ["typedoc/index"],
     "Classes": [
       "typedoc/classes/baseerror",
       "typedoc/classes/configurationerror",


### PR DESCRIPTION
This pull request allows the following:

```tsx
const backendRunner = new runners.GeneralPurposeRunner({
  service: "api",
  image: "xxxxx.dkr.ecr.xxxx.amazonaws.com/api",
  props: {
    environment
  },
  networks: ["private"],
  dependsOn: [databaseRunner, redisRunner, s3Runner],
  getResponsivenessCheckCommand: containerId => {
    return ` \
      docker exec ${containerId} \
      sh -c "wget --quiet --tries=1 --spider http://localhost:7001/.well-known/apollo/server-health" \
    `;
  }
});
```

______


 Alternatively, we could omit to inject the `containerId`, in case we enforce that the responsiveness check command must always be executed inside the container. Is there a use-case for running the command outside the container?

In that case, the config option would look similar to this:

`responsivenessCheckCommand: 'sh -c "wget --quiet --tries=1 --spider http://localhost:7001/.well-known/apollo/server-health'`

The underlying implementation could than do the `docker run exec containerId ...` stuff.

Furthermore, it might be possible to reuse the health check defined in the Docker Container in order to check whether a container is ready or not?

@erikengervall Let me know how you think about this!