### PR TITLE
feat: allow containers to connect to host machine/dockest inside container support

### DIFF
--- a/examples/aws-code-build-example/.gitignore
+++ b/examples/aws-code-build-example/.gitignore
@@ -1,0 +1,2 @@
+dockest.tgz
+.artifacts

--- a/examples/aws-code-build-example/README.md
+++ b/examples/aws-code-build-example/README.md
@@ -20,4 +20,4 @@ This test should also pass when not being run inside a container.
 
 # Development
 
-Dockest must be bundeled as a .tgz and put inside this folder, because the codebuild container cannot resolve the parent directories.
+Dockest must be bundeled as a .tgz and put inside this folder, because the codebuild container cannot resolve the parent directories (check `run_tests.sh`).

--- a/examples/aws-code-build-example/README.md
+++ b/examples/aws-code-build-example/README.md
@@ -1,0 +1,23 @@
+# aws-code-build-example
+
+Exampel that showcases usage with AWS Codebuild
+
+It can be reused for any CI System that runs your build inside a docker container with an injected docker socket.
+
+## Running the build
+
+```bash
+./run_tests.sh
+```
+
+This test should also pass when not being run inside a container.
+
+## Differences to running dockest on the host
+
+- Dockest creates a network that connects the container that runs dockest to the other containers
+- Dockest uses the target ports on the containers (instead of the published on the host)
+- Services can be accessed via their service name as the hostname
+
+# Development
+
+Dockest must be bundeled as a .tgz and put inside this folder, because the codebuild container cannot resolve the parent directories.

--- a/examples/aws-code-build-example/app/Dockerfile
+++ b/examples/aws-code-build-example/app/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:12-alpine
+
+COPY package.json /app/package.json
+RUN sh -c "cd /app && yarn install" 
+COPY index.js /app/index.js
+
+EXPOSE 9000
+
+CMD ["node", "/app/index.js"]

--- a/examples/aws-code-build-example/app/index.js
+++ b/examples/aws-code-build-example/app/index.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const bodyParser = require('body-parser')
+const app = require('express')()
+const fetch = require('node-fetch')
+
+app.use(bodyParser.text())
+
+app.post('/', (req, res) => {
+  const url = req.body
+
+  res.status(200).send('OK.')
+
+  setTimeout(() => {
+    fetch(url)
+  }, 2000)
+})
+
+app.listen(9000)

--- a/examples/aws-code-build-example/app/package.json
+++ b/examples/aws-code-build-example/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "body-parser": "1.19.0",
+    "express": "4.17.1",
+    "node-fetch": "2.6.0"
+  }
+}

--- a/examples/aws-code-build-example/buildspec.yml
+++ b/examples/aws-code-build-example/buildspec.yml
@@ -1,0 +1,13 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      # docker in docker integration
+      - nohup /usr/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+      - timeout -t 15 sh -c "until docker info; do echo .; sleep 1; done"
+      - yarn
+
+  build:
+    commands:
+      - yarn test

--- a/examples/aws-code-build-example/codebuild_build.sh
+++ b/examples/aws-code-build-example/codebuild_build.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+function allOSRealPath() {
+    if isOSWindows
+    then
+        path=""
+        case $1 in
+            .* ) path="$PWD/${1#./}" ;;
+            /* ) path="$1" ;;
+            *  ) path="/$1" ;;
+        esac
+
+        echo "/$path" | sed -e 's/\\/\//g' -e 's/://' -e 's/./\U&/3'
+    else
+        case $1 in
+            /* ) echo "$1"; exit;;
+            *  ) echo "$PWD/${1#./}"; exit;;
+        esac
+    fi
+}
+
+function isOSWindows() {
+    if [ $OSTYPE == "msys" ]
+    then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function usage {
+    echo "usage: codebuild_build.sh [-i image_name] [-a artifact_output_directory] [options]"
+    echo "Required:"
+    echo "  -i        Used to specify the customer build container image."
+    echo "  -a        Used to specify an artifact output directory."
+    echo "Options:"
+    echo "  -l IMAGE  Used to override the default local agent image."
+    echo "  -s        Used to specify source information. Defaults to the current working directory for primary source."
+    echo "               * First (-s) is for primary source"
+    echo "               * Use additional (-s) in <sourceIdentifier>:<sourceLocation> format for secondary source"
+    echo "               * For sourceIdentifier, use a value that is fewer than 128 characters and contains only alphanumeric characters and underscores"
+    echo "  -c        Use the AWS configuration and credentials from your local host. This includes ~/.aws and any AWS_* environment variables."
+    echo "  -p        Used to specify the AWS CLI Profile."
+    echo "  -b FILE   Used to specify a buildspec override file. Defaults to buildspec.yml in the source directory."
+    echo "  -m        Used to mount the source directory to the customer build container directly."
+    echo "  -e FILE   Used to specify a file containing environment variables."
+    echo "            (-e) File format expectations:"
+    echo "               * Each line is in VAR=VAL format"
+    echo "               * Lines beginning with # are processed as comments and ignored"
+    echo "               * Blank lines are ignored"
+    echo "               * File can be of type .env or .txt"
+    echo "               * There is no special handling of quotation marks, meaning they will be part of the VAL"
+    exit 1
+}
+
+image_flag=false
+artifact_flag=false
+awsconfig_flag=false
+mount_src_dir_flag=false
+
+while getopts "cmi:a:s:b:e:l:p:h" opt; do
+    case $opt in
+        i  ) image_flag=true; image_name=$OPTARG;;
+        a  ) artifact_flag=true; artifact_dir=$OPTARG;;
+        b  ) buildspec=$OPTARG;;
+        c  ) awsconfig_flag=true;;
+        m  ) mount_src_dir_flag=true;;
+        s  ) source_dirs+=("$OPTARG");;
+        e  ) environment_variable_file=$OPTARG;;
+        l  ) local_agent_image=$OPTARG;;
+        p  ) aws_profile=$OPTARG;;
+        h  ) usage; exit;;
+        \? ) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+        :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+        *  ) echo "Invalid option: -$OPTARG" >&2; exit 1;;
+    esac
+done
+
+if  ! $image_flag
+then
+    echo "The image name flag (-i) must be included for a build to run" >&2
+fi
+
+if  ! $artifact_flag
+then
+    echo "The artifact directory (-a) must be included for a build to run" >&2
+fi
+
+if  ! $image_flag ||  ! $artifact_flag
+then
+    exit 1
+fi
+
+docker_command="docker run -it "
+if isOSWindows
+then
+    docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "
+else
+    docker_command+="-v /var/run/docker.sock:/var/run/docker.sock -e "
+fi
+
+docker_command+="\"IMAGE_NAME=$image_name\" -e \
+    \"ARTIFACTS=$(allOSRealPath $artifact_dir)\""
+
+if [ -z "$source_dirs" ]
+then
+    docker_command+=" -e \"SOURCE=$(allOSRealPath $PWD)\""
+else
+    for index in "${!source_dirs[@]}"; do
+        if [ $index -eq 0 ]
+        then
+            docker_command+=" -e \"SOURCE=$(allOSRealPath ${source_dirs[$index]})\""
+        else
+            identifier=${source_dirs[$index]%%:*}
+            src_dir=$(allOSRealPath ${source_dirs[$index]#*:})
+
+            docker_command+=" -e \"SECONDARY_SOURCE_$index=$identifier:$src_dir\""
+        fi
+    done
+fi
+
+if [ -n "$buildspec" ]
+then
+    docker_command+=" -e \"BUILDSPEC=$(allOSRealPath $buildspec)\""
+fi
+
+if [ -n "$environment_variable_file" ]
+then
+    environment_variable_file_path=$(allOSRealPath "$environment_variable_file")
+    environment_variable_file_dir=$(dirname "$environment_variable_file_path")
+    environment_variable_file_basename=$(basename "$environment_variable_file")
+    docker_command+=" -v \"$environment_variable_file_dir:/LocalBuild/envFile/\" -e \"ENV_VAR_FILE=$environment_variable_file_basename\""
+fi
+
+if [ -n "$local_agent_image" ]
+then
+    docker_command+=" -e \"LOCAL_AGENT_IMAGE_NAME=$local_agent_image\""
+fi
+
+if $awsconfig_flag
+then
+    if [ -d "$HOME/.aws" ]
+    then
+        configuration_file_path=$(allOSRealPath "$HOME/.aws")
+        docker_command+=" -e \"AWS_CONFIGURATION=$configuration_file_path\""
+    else
+        docker_command+=" -e \"AWS_CONFIGURATION=NONE\""
+    fi
+
+    if [ -n "$aws_profile" ]
+    then
+        docker_command+=" -e \"AWS_PROFILE=$aws_profile\""
+    fi
+
+    docker_command+="$(env | grep ^AWS_ | while read -r line; do echo " -e \"$line\""; done )"
+fi
+
+if $mount_src_dir_flag
+then
+    docker_command+=" -e \"MOUNT_SOURCE_DIRECTORY=TRUE\""
+fi
+
+if isOSWindows
+then
+    docker_command+=" -e \"INITIATOR=$USERNAME\""
+else
+    docker_command+=" -e \"INITIATOR=$USER\""
+fi
+
+docker_command+=" amazon/aws-codebuild-local:latest"
+
+# Note we do not expose the AWS_SECRET_ACCESS_KEY or the AWS_SESSION_TOKEN
+exposed_command=$docker_command
+secure_variables=( "AWS_SECRET_ACCESS_KEY=" "AWS_SESSION_TOKEN=")
+for variable in "${secure_variables[@]}"
+do
+    exposed_command="$(echo $exposed_command | sed "s/\($variable\)[^ ]*/\1********\"/")"
+done
+
+echo "Build Command:"
+echo ""
+echo $exposed_command
+echo ""
+
+eval $docker_command

--- a/examples/aws-code-build-example/codebuild_build.sh
+++ b/examples/aws-code-build-example/codebuild_build.sh
@@ -91,7 +91,7 @@ then
     exit 1
 fi
 
-docker_command="docker run -it "
+docker_command="docker run "
 if isOSWindows
 then
     docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "

--- a/examples/aws-code-build-example/dockest.ts
+++ b/examples/aws-code-build-example/dockest.ts
@@ -1,0 +1,24 @@
+import Dockest, { runners, logLevel } from 'dockest'
+
+const runner = new runners.GeneralPurposeRunner({
+  service: 'website',
+  build: './app',
+  ports: [
+    {
+      target: 9000,
+      published: 9000,
+    },
+  ],
+  responsivenessTimeout: 5,
+  connectionTimeout: 5,
+})
+
+const dockest = new Dockest({
+  opts: {
+    logLevel: logLevel.DEBUG,
+  },
+})
+
+dockest.attachRunners([runner])
+
+dockest.run()

--- a/examples/aws-code-build-example/integration-test/hello-world.spec.ts
+++ b/examples/aws-code-build-example/integration-test/hello-world.spec.ts
@@ -1,0 +1,46 @@
+import http from 'http'
+import fetch from 'node-fetch'
+import isDocker from 'is-docker'
+
+const TARGET_HOST = isDocker() ? 'website' : 'localhost'
+
+// hostname is either our docker container hostname or if not run inside a docker container the docker host
+const HOSTNAME = isDocker() ? process.env.HOSTNAME : 'host.docker.internal'
+const PORT = 8080
+
+let server: http.Server
+
+afterEach(async () => {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close(err => {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve()
+      })
+    })
+  }
+})
+
+test('can send a request to the container and it can send a request to us', async done => {
+  await new Promise(resolve => {
+    server = http
+      .createServer((_req, res) => {
+        res.write('Hello World!')
+        res.end()
+        done()
+      })
+      .listen(PORT, () => {
+        console.log(`Serving on http://${HOSTNAME}:${PORT}`)
+        resolve()
+      })
+  })
+
+  const res = await fetch(`http://${TARGET_HOST}:9000`, {
+    method: 'post',
+    body: `http://${HOSTNAME}:${PORT}`,
+  }).then(res => res.text())
+  expect(res).toEqual('OK.')
+})

--- a/examples/aws-code-build-example/integration-test/hello-world.spec.ts
+++ b/examples/aws-code-build-example/integration-test/hello-world.spec.ts
@@ -1,11 +1,11 @@
 import http from 'http'
 import fetch from 'node-fetch'
-import isDocker from 'is-docker'
+import { getHostAddress, getServiceAddress } from 'dockest/dist/test-helper'
 
-const TARGET_HOST = isDocker() ? 'website' : 'localhost'
+const TARGET_HOST = getServiceAddress('website', 9000)
 
 // hostname is either our docker container hostname or if not run inside a docker container the docker host
-const HOSTNAME = isDocker() ? process.env.HOSTNAME : 'host.docker.internal'
+const HOSTNAME = getHostAddress()
 const PORT = 8080
 
 let server: http.Server
@@ -38,7 +38,7 @@ test('can send a request to the container and it can send a request to us', asyn
       })
   })
 
-  const res = await fetch(`http://${TARGET_HOST}:9000`, {
+  const res = await fetch(`http://${TARGET_HOST}`, {
     method: 'post',
     body: `http://${HOSTNAME}:${PORT}`,
   }).then(res => res.text())

--- a/examples/aws-code-build-example/jest.config.js
+++ b/examples/aws-code-build-example/jest.config.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  roots: ['<rootDir>/integration-test'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+}

--- a/examples/aws-code-build-example/package.json
+++ b/examples/aws-code-build-example/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "aws--codebuild-example",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "n1ru4l <laurinquast@googlemail.com>",
+  "license": "MIT",
+  "private": true,
+  "devDependencies": {
+    "@types/jest": "24.0.18",
+    "@types/node": "12.7.5",
+    "@types/node-fetch": "2.5.2",
+    "is-docker": "2.0.0",
+    "jest": "24.9.0",
+    "node-fetch": "2.6.0",
+    "ts-jest": "24.1.0",
+    "ts-node": "8.4.1",
+    "typescript": "3.6.3"
+  },
+  "scripts": {
+    "test": "ts-node dockest.ts"
+  },
+  "dependencies": {
+    "dockest": "file:./dockest.tgz"
+  }
+}

--- a/examples/aws-code-build-example/run_tests.sh
+++ b/examples/aws-code-build-example/run_tests.sh
@@ -7,8 +7,8 @@ yarn pack --filename examples/aws-code-build-example/dockest.tgz
 cd examples/aws-code-build-example
 
 # build dockest
-yarn install
-yarn test
+# yarn install
+# yarn test
 
 # build with dockest inside docker container
 ./codebuild_build.sh -i n1ru4l/aws-codebuild-node -a .artifacts

--- a/examples/aws-code-build-example/run_tests.sh
+++ b/examples/aws-code-build-example/run_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+cd ../..
+yarn build
+yarn pack --filename examples/aws-code-build-example/dockest.tgz
+cd examples/aws-code-build-example
+
+# build dockest
+yarn test
+
+# build with dockest inside docker container
+./codebuild_build.sh -i n1ru4l/aws-codebuild-node -a .artifacts

--- a/examples/aws-code-build-example/run_tests.sh
+++ b/examples/aws-code-build-example/run_tests.sh
@@ -7,6 +7,7 @@ yarn pack --filename examples/aws-code-build-example/dockest.tgz
 cd examples/aws-code-build-example
 
 # build dockest
+yarn install
 yarn test
 
 # build with dockest inside docker container

--- a/examples/aws-code-build-example/run_tests.sh
+++ b/examples/aws-code-build-example/run_tests.sh
@@ -7,8 +7,10 @@ yarn pack --filename examples/aws-code-build-example/dockest.tgz
 cd examples/aws-code-build-example
 
 # build dockest
-# yarn install
-# yarn test
+yarn cache clean
+yarn install --no-lockfile
+yarn test
 
 # build with dockest inside docker container
+rm -rf node_modules
 ./codebuild_build.sh -i n1ru4l/aws-codebuild-node -a .artifacts

--- a/examples/aws-code-build-example/run_tests.sh
+++ b/examples/aws-code-build-example/run_tests.sh
@@ -13,4 +13,4 @@ yarn test
 
 # build with dockest inside docker container
 rm -rf node_modules
-./codebuild_build.sh -i n1ru4l/aws-codebuild-node -a .artifacts
+./codebuild_build.sh -i n1ru4l/aws-codebuild-node:7712cfae8d65fd3b704f74e84f688739de5bd357 -a .artifacts

--- a/examples/aws-code-build-example/tsconfig.json
+++ b/examples/aws-code-build-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "lib": ["es2019"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2019",
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["./integration-test/*.ts", "dockest.ts"]
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,7 +13,8 @@
     "test:2": "cd multiple-projects && yarn test && cd ..",
     "test:3": "cd node-to-node && yarn test && cd ..",
     "test:4": "cd inherit-from-compose-file && yarn test && cd ..",
-    "test": "yarn test:1 && yarn test:2 && yarn test:3 && yarn test:4"
+    "test:aws-code-build-example": "cd aws-code-build-example && ./run_tests.sh",
+    "test": "yarn test:1 && yarn test:2 && yarn test:3 && yarn test:4 && yarn test:aws-code-build-example"
   },
   "devDependencies": {
     "ts-node": "^8.3.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "execa": "^2.0.4",
+    "is-docker": "^2.0.0",
     "js-yaml": "^3.13.1",
     "ramda": "^0.26.1"
   },

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,8 @@ Dockest {
   "config": Object {
     "$": Object {
       "failedTeardowns": Array [],
+      "hostname": "host.docker.internal",
+      "isInsideDockerContainer": false,
       "jestRanWithResult": false,
       "perfStart": 0,
     },
@@ -28,6 +30,7 @@ Dockest {
         "createResponsivenessCheckCmd": null,
         "getComposeService": [Function],
         "initializer": "",
+        "isBridgeNetworkMode": false,
         "logger": Logger {
           "debug": [Function],
           "error": [Function],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,6 +71,7 @@ export const INTERNAL_CONFIG = {
   failedTeardowns: [],
   jestRanWithResult: false,
   perfStart: 0,
+  isInsideDockerContainer: false,
 }
 
 export const PROCESS_TEST_ENV = 'dockest-test'
@@ -79,3 +80,5 @@ export const GENERATED_COMPOSE_FILE_NAME = 'docker-compose.dockest-generated.yml
 export const GENERATED_RUNNER_COMPOSE_FILE_NAME = 'docker-compose.dockest-generated-runner.yml'
 export const GENERATED_COMPOSE_FILE_PATH = `${process.cwd()}/${GENERATED_COMPOSE_FILE_NAME}`
 export const GENERATED_RUNNER_COMPOSE_FILE_PATH = `${process.cwd()}/${GENERATED_RUNNER_COMPOSE_FILE_NAME}`
+
+export const BRIDGE_NETWORK_NAME = `dockest_bridge_network`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,7 @@ export const INTERNAL_CONFIG = {
   jestRanWithResult: false,
   perfStart: 0,
   isInsideDockerContainer: false,
+  hostname: process.env.HOSTNAME || 'host.docker.internal',
 }
 
 export const PROCESS_TEST_ENV = 'dockest-test'

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,13 @@ class Dockest {
     this.config.$.perfStart = Date.now()
     this.config.$.isInsideDockerContainer = isDocker()
 
+    if (this.config.$.isInsideDockerContainer) {
+      this.config.runners.forEach(runner => {
+        runner.isBridgeNetworkMode = true
+        runner.runnerConfig.host = runner.runnerConfig.service
+      })
+    }
+
     const { composeFileConfig } = onInstantiation(this.config)
 
     for (const runner of this.config.runners) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ interface InternalConfig {
   jestRanWithResult: boolean
   perfStart: number
   isInsideDockerContainer: boolean
+  hostname: string
 }
 export interface DockestConfig {
   runners: ArrayAtLeastOne<Runner>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import isDocker from 'is-docker'
 import { DEFAULT_USER_CONFIG, LOG_LEVEL, INTERNAL_CONFIG } from './constants'
 import { ErrorPayload, ObjStrStr, ArrayAtLeastOne } from './@types'
 import { JestConfig } from './onRun/runJest'
@@ -28,6 +29,7 @@ interface InternalConfig {
   failedTeardowns: { service: string; containerId: string }[]
   jestRanWithResult: boolean
   perfStart: number
+  isInsideDockerContainer: boolean
 }
 export interface DockestConfig {
   runners: ArrayAtLeastOne<Runner>
@@ -55,6 +57,7 @@ class Dockest {
 
   public run = async (): Promise<void> => {
     this.config.$.perfStart = Date.now()
+    this.config.$.isInsideDockerContainer = isDocker()
 
     const { composeFileConfig } = onInstantiation(this.config)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import isDocker from 'is-docker'
+import isDocker from 'is-docker' // eslint-disable-line import/default
 import { DEFAULT_USER_CONFIG, LOG_LEVEL, INTERNAL_CONFIG } from './constants'
 import { ErrorPayload, ObjStrStr, ArrayAtLeastOne } from './@types'
 import { JestConfig } from './onRun/runJest'

--- a/src/onInstantiation/generateComposeFile/__snapshots__/createComposeObjFromRunners.spec.ts.snap
+++ b/src/onInstantiation/generateComposeFile/__snapshots__/createComposeObjFromRunners.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`createComposeObjFromRunners should create composeObj from all initializ
 Object {
   "services": Object {
     "general": Object {
+      "extra_hosts": Array [],
       "image": "general/image:123",
       "ports": Array [],
     },
@@ -19,6 +20,7 @@ Object {
         "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": 1,
         "KAFKA_ZOOKEEPER_CONNECT": "zookeeper:2181",
       },
+      "extra_hosts": Array [],
       "image": "kafka/image:123",
       "ports": Array [
         Object {
@@ -33,6 +35,7 @@ Object {
         "POSTGRES_PASSWORD": "_",
         "POSTGRES_USER": "_",
       },
+      "extra_hosts": Array [],
       "image": "postgres/image:123",
       "ports": Array [
         Object {
@@ -42,6 +45,7 @@ Object {
       ],
     },
     "redis": Object {
+      "extra_hosts": Array [],
       "image": "redis/image:123",
       "ports": Array [
         Object {
@@ -54,6 +58,7 @@ Object {
       "environment": Object {
         "ZOOKEEPER_CLIENT_PORT": 2181,
       },
+      "extra_hosts": Array [],
       "image": "zookeeper/image:123",
       "ports": Array [
         Object {
@@ -76,6 +81,7 @@ Object {
         "POSTGRES_PASSWORD": "_",
         "POSTGRES_USER": "_",
       },
+      "extra_hosts": Array [],
       "image": "postgres/image:123",
       "ports": Array [
         Object {

--- a/src/onInstantiation/generateComposeFile/__snapshots__/createComposeObjFromRunners.spec.ts.snap
+++ b/src/onInstantiation/generateComposeFile/__snapshots__/createComposeObjFromRunners.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`createComposeObjFromRunners should create composeObj from all initializ
 Object {
   "services": Object {
     "general": Object {
-      "extra_hosts": Array [],
       "image": "general/image:123",
       "ports": Array [],
     },
@@ -20,7 +19,6 @@ Object {
         "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": 1,
         "KAFKA_ZOOKEEPER_CONNECT": "zookeeper:2181",
       },
-      "extra_hosts": Array [],
       "image": "kafka/image:123",
       "ports": Array [
         Object {
@@ -35,7 +33,6 @@ Object {
         "POSTGRES_PASSWORD": "_",
         "POSTGRES_USER": "_",
       },
-      "extra_hosts": Array [],
       "image": "postgres/image:123",
       "ports": Array [
         Object {
@@ -45,7 +42,6 @@ Object {
       ],
     },
     "redis": Object {
-      "extra_hosts": Array [],
       "image": "redis/image:123",
       "ports": Array [
         Object {
@@ -58,7 +54,6 @@ Object {
       "environment": Object {
         "ZOOKEEPER_CLIENT_PORT": 2181,
       },
-      "extra_hosts": Array [],
       "image": "zookeeper/image:123",
       "ports": Array [
         Object {
@@ -81,7 +76,6 @@ Object {
         "POSTGRES_PASSWORD": "_",
         "POSTGRES_USER": "_",
       },
-      "extra_hosts": Array [],
       "image": "postgres/image:123",
       "ports": Array [
         Object {

--- a/src/onInstantiation/generateComposeFile/__snapshots__/transformComposeObjToRunners.spec.ts.snap
+++ b/src/onInstantiation/generateComposeFile/__snapshots__/transformComposeObjToRunners.spec.ts.snap
@@ -7,6 +7,7 @@ Array [
     "createResponsivenessCheckCmd": [Function],
     "getComposeService": [Function],
     "initializer": "",
+    "isBridgeNetworkMode": false,
     "logger": Logger {
       "debug": [Function],
       "error": [Function],
@@ -47,6 +48,7 @@ Array [
     "createResponsivenessCheckCmd": [Function],
     "getComposeService": [Function],
     "initializer": "",
+    "isBridgeNetworkMode": false,
     "logger": Logger {
       "debug": [Function],
       "error": [Function],

--- a/src/onInstantiation/generateComposeFile/createComposeObjFromRunners.ts
+++ b/src/onInstantiation/generateComposeFile/createComposeObjFromRunners.ts
@@ -1,3 +1,4 @@
+import execa from 'execa'
 import { ComposeService, DependsOn, ComposeFile } from '../../runners/@types'
 import { DockestConfig } from '../../index'
 
@@ -18,6 +19,16 @@ export default (config: DockestConfig, dockerComposeFileVersion: string) => {
     services: {},
   }
 
+  const extra_hosts: string[] = []
+
+  if (!config.$.isInsideDockerContainer) {
+    if (process.platform === 'linux') {
+      const command = `ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'`
+      const result = execa.sync(command, { reject: false })
+      extra_hosts.push(`host.docker.internal:${result.stdout}`)
+    }
+  }
+
   config.runners.forEach(runner => {
     const {
       runnerConfig: { service, dependsOn },
@@ -29,7 +40,7 @@ export default (config: DockestConfig, dockerComposeFileVersion: string) => {
 
     composeObj.services = {
       ...composeObj.services,
-      [service]: composeService,
+      [service]: { ...composeService, extra_hosts },
       ...depComposeServices,
     }
   })

--- a/src/onInstantiation/generateComposeFile/createComposeObjFromRunners.ts
+++ b/src/onInstantiation/generateComposeFile/createComposeObjFromRunners.ts
@@ -1,4 +1,3 @@
-import execa from 'execa'
 import { ComposeService, DependsOn, ComposeFile } from '../../runners/@types'
 import { DockestConfig } from '../../index'
 
@@ -19,16 +18,6 @@ export default (config: DockestConfig, dockerComposeFileVersion: string) => {
     services: {},
   }
 
-  const extra_hosts: string[] = []
-
-  if (!config.$.isInsideDockerContainer) {
-    if (process.platform === 'linux') {
-      const command = `ip -4 addr show docker0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'`
-      const result = execa.sync(command, { reject: false })
-      extra_hosts.push(`host.docker.internal:${result.stdout}`)
-    }
-  }
-
   config.runners.forEach(runner => {
     const {
       runnerConfig: { service, dependsOn },
@@ -40,7 +29,7 @@ export default (config: DockestConfig, dockerComposeFileVersion: string) => {
 
     composeObj.services = {
       ...composeObj.services,
-      [service]: { ...composeService, extra_hosts },
+      [service]: { ...composeService },
       ...depComposeServices,
     }
   })

--- a/src/onInstantiation/generateComposeFile/index.ts
+++ b/src/onInstantiation/generateComposeFile/index.ts
@@ -43,6 +43,9 @@ export default (config: DockestConfig, yaml = yamlLib, fs = fsLib) => {
 
   // write final config to fs
   fs.writeFileSync(GENERATED_COMPOSE_FILE_PATH, yaml.safeDump(composeObjFromComposeFile))
+  // set environment variable that can be used with the test-helpers
+  // jest.runCLI will pass this environment variable into the testcase runners
+  process.env.DOCKEST_INTERNAL_CONFIG = JSON.stringify(composeObjFromComposeFile)
 
   return { composeFileConfig: composeObjFromComposeFile }
 }

--- a/src/onRun/createBridgeNetwork.ts
+++ b/src/onRun/createBridgeNetwork.ts
@@ -1,0 +1,11 @@
+import execaWrapper from '../utils/execaWrapper'
+import { BRIDGE_NETWORK_NAME } from '../constants'
+
+export default async () => {
+  const command = `
+    docker network create \
+      --driver bridge \
+      ${BRIDGE_NETWORK_NAME}
+  `
+  await execaWrapper(command)
+}

--- a/src/onRun/index.ts
+++ b/src/onRun/index.ts
@@ -24,7 +24,7 @@ const onRun = async (config: DockestConfig) => {
 
   if (isInsideDockerContainer) {
     await createBridgeNetwork()
-    await joinBridgeNetwork(hostname)
+    await joinBridgeNetwork(hostname, 'host.dockest-runner.internal')
   }
 
   await waitForRunnersReadiness(config)

--- a/src/onRun/index.ts
+++ b/src/onRun/index.ts
@@ -1,14 +1,14 @@
 import dockerComposeUp from './dockerComposeUp'
 import runJest from './runJest'
 import waitForRunnersReadiness from './waitForRunnersReadiness'
-import { DockestConfig } from '../index'
-import Logger from '../Logger'
-import sleepForX from '../utils/sleepForX'
-import teardownSingle from '../utils/teardownSingle'
 import createBridgeNetwork from './createBridgeNetwork'
 import joinBridgeNetwork from './joinBridgeNetwork'
 import removeBridgeNetwork from './removeBridgeNetwork'
 import leaveBridgeNetwork from './leaveBridgeNetwork'
+import { DockestConfig } from '../index'
+import Logger from '../Logger'
+import sleepForX from '../utils/sleepForX'
+import teardownSingle from '../utils/teardownSingle'
 
 const onRun = async (config: DockestConfig) => {
   const {

--- a/src/onRun/joinBridgeNetwork.ts
+++ b/src/onRun/joinBridgeNetwork.ts
@@ -1,0 +1,12 @@
+import execaWrapper from '../utils/execaWrapper'
+import { BRIDGE_NETWORK_NAME } from '../constants'
+
+export default async (containerId: string, alias?: string) => {
+  const command = `
+    docker network connect \
+      ${BRIDGE_NETWORK_NAME} \
+      ${alias ? `--alias ${alias}` : ''} \
+      ${containerId}
+  `
+  await execaWrapper(command)
+}

--- a/src/onRun/leaveBridgeNetwork.ts
+++ b/src/onRun/leaveBridgeNetwork.ts
@@ -1,0 +1,11 @@
+import execaWrapper from '../utils/execaWrapper'
+import { BRIDGE_NETWORK_NAME } from '../constants'
+
+export default async (containerId: string) => {
+  const command = `
+  docker network disconnect \
+      ${BRIDGE_NETWORK_NAME} \
+      ${containerId}
+  `
+  await execaWrapper(command)
+}

--- a/src/onRun/removeBridgeNetwork.ts
+++ b/src/onRun/removeBridgeNetwork.ts
@@ -1,0 +1,10 @@
+import execaWrapper from '../utils/execaWrapper'
+import { BRIDGE_NETWORK_NAME } from '../constants'
+
+export default async () => {
+  const command = `
+  docker network rm \
+      ${BRIDGE_NETWORK_NAME}
+  `
+  await execaWrapper(command)
+}

--- a/src/onRun/waitForRunnersReadiness/checkConnection.ts
+++ b/src/onRun/waitForRunnersReadiness/checkConnection.ts
@@ -30,16 +30,13 @@ export { testables }
 
 export default async (runner: Runner) => {
   const {
-    runnerConfig: { service, connectionTimeout, ports },
+    runnerConfig: { host, service, connectionTimeout, ports },
     logger,
   } = runner
 
-  const host =
-    typeof runner.runnerConfig.host === 'function'
-      ? runner.runnerConfig.host(runner.containerId)
-      : runner.runnerConfig.host
+  const portKey = runner.isBridgeNetworkMode ? 'target' : 'published'
 
-  for (const { published: port } of ports) {
+  for (const { [portKey]: port } of ports) {
     const recurse = async (connectionTimeout: number) => {
       logger.debug(`Checking connection (${host}:${port}) (Timeout in: ${connectionTimeout}s)`)
 

--- a/src/onRun/waitForRunnersReadiness/checkConnection.ts
+++ b/src/onRun/waitForRunnersReadiness/checkConnection.ts
@@ -30,9 +30,14 @@ export { testables }
 
 export default async (runner: Runner) => {
   const {
-    runnerConfig: { service, connectionTimeout, host, ports },
+    runnerConfig: { service, connectionTimeout, ports },
     logger,
   } = runner
+
+  const host =
+    typeof runner.runnerConfig.host === 'function'
+      ? runner.runnerConfig.host(runner.containerId)
+      : runner.runnerConfig.host
 
   for (const { published: port } of ports) {
     const recurse = async (connectionTimeout: number) => {

--- a/src/onRun/waitForRunnersReadiness/fixRunnerHostAccessOnLinux.ts
+++ b/src/onRun/waitForRunnersReadiness/fixRunnerHostAccessOnLinux.ts
@@ -1,0 +1,10 @@
+import { Runner } from '../../runners/@types'
+import { execa } from '../../index'
+
+export default async (runner: Runner) => {
+  const command = ` \
+    docker exec ${runner.containerId} \
+      /bin/sh -c "ip -4 route list match 0/0 | awk '{print \\$3\\" host.docker.internal\\"}' >> /etc/hosts"
+  `
+  await execa(command)
+}

--- a/src/onRun/waitForRunnersReadiness/index.spec.ts
+++ b/src/onRun/waitForRunnersReadiness/index.spec.ts
@@ -3,6 +3,7 @@ import _resolveContainerId from './resolveContainerId'
 import _checkConnection from './checkConnection'
 import _checkResponsiveness from './checkResponsiveness'
 import _runRunnerCommands from './runRunnerCommands'
+import _fixRunnerHostAccessOnLinux from './fixRunnerHostAccessOnLinux'
 import testUtils from '../../testUtils'
 
 const {
@@ -15,11 +16,13 @@ const checkConnection = _checkConnection as jest.Mock
 const checkResponsiveness = _checkResponsiveness as jest.Mock
 const resolveContainerId = _resolveContainerId as jest.Mock
 const runRunnerCommands = _runRunnerCommands as jest.Mock
+const fixRunnerHostAccessOnLinux = _fixRunnerHostAccessOnLinux as jest.Mock
 
 jest.mock('./resolveContainerId')
 jest.mock('./checkConnection')
 jest.mock('./checkResponsiveness')
 jest.mock('./runRunnerCommands')
+jest.mock('./fixRunnerHostAccessOnLinux')
 
 describe('waitForRunnersReadiness', () => {
   const runners = [generalPurposeRunner]
@@ -29,6 +32,7 @@ describe('waitForRunnersReadiness', () => {
     checkConnection.mockClear()
     checkResponsiveness.mockClear()
     runRunnerCommands.mockClear()
+    fixRunnerHostAccessOnLinux.mockClear()
   })
 
   it('should work for a simple one-runner application', async () => {

--- a/src/onRun/waitForRunnersReadiness/index.ts
+++ b/src/onRun/waitForRunnersReadiness/index.ts
@@ -4,11 +4,15 @@ import resolveContainerId from './resolveContainerId'
 import runRunnerCommands from './runRunnerCommands'
 import { Runner } from '../../runners/@types'
 import { DockestConfig } from '../../index'
+import joinBridgeNetwork from '../joinBridgeNetwork'
 
-const setupRunner = async (runner: Runner, initializer: string) => {
+const setupRunner = async (runner: Runner, initializer: string, mustJoinBridgeNetwork: boolean) => {
   runner.logger.info('Setup initiated')
 
   await resolveContainerId(runner)
+  if (mustJoinBridgeNetwork) {
+    await joinBridgeNetwork(runner.containerId, runner.runnerConfig.service)
+  }
   await checkConnection(runner)
   await checkResponsiveness(runner)
   await runRunnerCommands(runner)
@@ -17,24 +21,24 @@ const setupRunner = async (runner: Runner, initializer: string) => {
   runner.logger.info('Setup successful', { nl: 1 })
 }
 
-const setupIfNotOngoing = async (runner: Runner, initializer: string) => {
+const setupIfNotOngoing = async (runner: Runner, initializer: string, mustJoinBridgeNetwork: boolean) => {
   if (!!runner.initializer) {
     runner.logger.info(
       `"${runner.runnerConfig.service}" has already been setup by "${runner.initializer}" - skipping`,
       { nl: 1 },
     )
   } else {
-    await setupRunner(runner, initializer)
+    await setupRunner(runner, initializer, mustJoinBridgeNetwork)
   }
 }
 
-const setupRunnerWithDependencies = async (runner: Runner) => {
+const setupRunnerWithDependencies = async (runner: Runner, mustJoinBridgeNetwork: boolean) => {
   // Setup runner's dependencies
   for (const depRunner of runner.runnerConfig.dependsOn) {
-    await setupIfNotOngoing(depRunner, runner.runnerConfig.service)
+    await setupIfNotOngoing(depRunner, runner.runnerConfig.service, mustJoinBridgeNetwork)
   }
 
-  await setupIfNotOngoing(runner, runner.runnerConfig.service)
+  await setupIfNotOngoing(runner, runner.runnerConfig.service, mustJoinBridgeNetwork)
 }
 
 export default async (config: DockestConfig) => {
@@ -42,9 +46,9 @@ export default async (config: DockestConfig) => {
 
   for (const runner of config.runners) {
     if (!!config.opts.runInBand) {
-      await setupRunnerWithDependencies(runner)
+      await setupRunnerWithDependencies(runner, config.$.isInsideDockerContainer)
     } else {
-      setupPromises.push(setupRunnerWithDependencies(runner))
+      setupPromises.push(setupRunnerWithDependencies(runner, config.$.isInsideDockerContainer))
     }
   }
 

--- a/src/onRun/waitForRunnersReadiness/index.ts
+++ b/src/onRun/waitForRunnersReadiness/index.ts
@@ -2,6 +2,7 @@ import checkConnection from './checkConnection'
 import checkResponsiveness from './checkResponsiveness'
 import resolveContainerId from './resolveContainerId'
 import runRunnerCommands from './runRunnerCommands'
+import fixRunnerHostAccessOnLinux from './fixRunnerHostAccessOnLinux'
 import { Runner } from '../../runners/@types'
 import { DockestConfig } from '../../index'
 import joinBridgeNetwork from '../joinBridgeNetwork'
@@ -13,6 +14,11 @@ const setupRunner = async (runner: Runner, initializer: string) => {
   if (runner.isBridgeNetworkMode) {
     await joinBridgeNetwork(runner.containerId, runner.runnerConfig.service)
   }
+
+  if (process.platform === 'linux' && !runner.isBridgeNetworkMode) {
+    await fixRunnerHostAccessOnLinux(runner)
+  }
+
   await checkConnection(runner)
   await checkResponsiveness(runner)
   await runRunnerCommands(runner)

--- a/src/runners/@types.ts
+++ b/src/runners/@types.ts
@@ -62,6 +62,7 @@ export interface BaseRunner {
   runnerConfig: RunnerConfig
   logger: Logger
   validateConfig: () => void
+  isBridgeNetworkMode: boolean
 }
 
 export interface SharedRequiredConfigProps {
@@ -80,7 +81,7 @@ export interface SharedDefaultableConfigProps {
   commands: string[]
   connectionTimeout: number
   dependsOn: DependsOn
-  host: string | ((containerId: string) => string)
+  host: string
   image: string | undefined
   networks: string[] | undefined
   ports: PortBindingType[]

--- a/src/runners/@types.ts
+++ b/src/runners/@types.ts
@@ -38,6 +38,7 @@ export interface ComposeService {
         target: string
       }
     | string
+  extra_hosts?: string[]
 }
 
 export interface ComposeFile {

--- a/src/runners/@types.ts
+++ b/src/runners/@types.ts
@@ -80,7 +80,7 @@ export interface SharedDefaultableConfigProps {
   commands: string[]
   connectionTimeout: number
   dependsOn: DependsOn
-  host: string
+  host: string | ((containerId: string) => string)
   image: string | undefined
   networks: string[] | undefined
   ports: PortBindingType[]

--- a/src/runners/GeneralPurposeRunner/__snapshots__/index.spec.ts.snap
+++ b/src/runners/GeneralPurposeRunner/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ GeneralPurposeRunner {
   "createResponsivenessCheckCmd": null,
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],
@@ -37,6 +38,7 @@ GeneralPurposeRunner {
   "createResponsivenessCheckCmd": null,
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],

--- a/src/runners/GeneralPurposeRunner/index.ts
+++ b/src/runners/GeneralPurposeRunner/index.ts
@@ -31,6 +31,7 @@ class GeneralPurposeRunner implements BaseRunner {
   public runnerConfig: GeneralPurposeRunnerConfig
   public logger: Logger
   public createResponsivenessCheckCmd: (() => string) | null = null
+  public isBridgeNetworkMode = false
 
   public constructor(config: RequiredConfigProps & Partial<DefaultableConfigProps> & Partial<OptionalConfigProps>) {
     this.runnerConfig = {

--- a/src/runners/KafkaRunner/__snapshots__/index.spec.ts.snap
+++ b/src/runners/KafkaRunner/__snapshots__/index.spec.ts.snap
@@ -5,6 +5,7 @@ KafkaRunner {
   "containerId": "",
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],
@@ -24,6 +25,7 @@ KafkaRunner {
         "containerId": "",
         "getComposeService": [Function],
         "initializer": "",
+        "isBridgeNetworkMode": false,
         "logger": Logger {
           "debug": [Function],
           "error": [Function],
@@ -74,6 +76,7 @@ KafkaRunner {
   "containerId": "",
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],
@@ -93,6 +96,7 @@ KafkaRunner {
         "containerId": "",
         "getComposeService": [Function],
         "initializer": "",
+        "isBridgeNetworkMode": false,
         "logger": Logger {
           "debug": [Function],
           "error": [Function],

--- a/src/runners/KafkaRunner/index.ts
+++ b/src/runners/KafkaRunner/index.ts
@@ -45,6 +45,7 @@ class KafkaRunner implements BaseRunner {
   public initializer = ''
   public runnerConfig: KafkaRunnerConfig
   public logger: Logger
+  public isBridgeNetworkMode = false
 
   public constructor(config: RequiredConfigProps & Partial<DefaultableConfigProps>) {
     this.runnerConfig = {

--- a/src/runners/PostgresRunner/__snapshots__/index.spec.ts.snap
+++ b/src/runners/PostgresRunner/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ PostgresRunner {
   "createResponsivenessCheckCmd": [Function],
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],
@@ -45,6 +46,7 @@ PostgresRunner {
   "createResponsivenessCheckCmd": [Function],
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],

--- a/src/runners/PostgresRunner/index.ts
+++ b/src/runners/PostgresRunner/index.ts
@@ -43,6 +43,7 @@ class PostgresRunner implements BaseRunner {
   public initializer = ''
   public runnerConfig: PostgresRunnerConfig
   public logger: Logger
+  public isBridgeNetworkMode = false
 
   public constructor(configUserInput: RequiredConfigProps & Partial<DefaultableConfigProps>) {
     this.runnerConfig = {

--- a/src/runners/RedisRunner/__snapshots__/index.spec.ts.snap
+++ b/src/runners/RedisRunner/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ RedisRunner {
   "createResponsivenessCheckCmd": [Function],
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],
@@ -43,6 +44,7 @@ RedisRunner {
   "createResponsivenessCheckCmd": [Function],
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],

--- a/src/runners/RedisRunner/index.ts
+++ b/src/runners/RedisRunner/index.ts
@@ -38,6 +38,7 @@ class RedisRunner implements BaseRunner {
   public initializer = ''
   public runnerConfig: RedisRunnerConfig
   public logger: Logger
+  public isBridgeNetworkMode = false
 
   public constructor(config: RequiredConfigProps & Partial<DefaultableConfigProps>) {
     this.runnerConfig = {

--- a/src/runners/ZooKeeperRunner/__snapshots__/index.spec.ts.snap
+++ b/src/runners/ZooKeeperRunner/__snapshots__/index.spec.ts.snap
@@ -5,6 +5,7 @@ ZooKeeperRunner {
   "containerId": "",
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],
@@ -40,6 +41,7 @@ ZooKeeperRunner {
   "containerId": "",
   "getComposeService": [Function],
   "initializer": "",
+  "isBridgeNetworkMode": false,
   "logger": Logger {
     "debug": [Function],
     "error": [Function],

--- a/src/runners/ZooKeeperRunner/index.ts
+++ b/src/runners/ZooKeeperRunner/index.ts
@@ -36,6 +36,7 @@ class ZooKeeperRunner implements BaseRunner {
   public initializer = ''
   public runnerConfig: ZooKeeperRunnerConfig
   public logger: Logger
+  public isBridgeNetworkMode = false
 
   public constructor(config: RequiredConfigProps & Partial<DefaultableConfigProps>) {
     this.runnerConfig = {

--- a/src/test-helper/index.ts
+++ b/src/test-helper/index.ts
@@ -1,0 +1,35 @@
+/* eslint-disable import/default */
+import isDocker from 'is-docker'
+import { ComposeFile } from '../runners/@types'
+
+const isInsideDockerContainer = isDocker()
+
+if (!process.env.DOCKEST_INTERNAL_CONFIG) {
+  throw new Error('Not executed inside dockest context.')
+}
+
+const config: ComposeFile = JSON.parse(process.env.DOCKEST_INTERNAL_CONFIG)
+
+export const getHostAddress = () => {
+  if (!isInsideDockerContainer) {
+    return `host.docker.internal`
+  }
+
+  return `host.dockest-runner.internal`
+}
+
+export const getServiceAddress = (serviceName: string, targetPort: number | string) => {
+  const service = config.services[serviceName]
+  if (!service) {
+    throw new Error(`Service "${serviceName}" does not exist.`)
+  }
+  const portBinding = service.ports.find(portBinding => portBinding.target === targetPort)
+  if (!portBinding) {
+    throw new Error(`Service "${serviceName}" has no target port ${portBinding}.`)
+  }
+
+  if (isInsideDockerContainer) {
+    return `${serviceName}:${portBinding.target}`
+  }
+  return `localhost:${portBinding.published}`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,6 +2351,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"


### PR DESCRIPTION
Closes #79

____________

Currently, the jest helpers are available via `dockest/dist/test-helper`, ideally that would be `dockest/test-helper`. This would require an additional build step.

The network name should be randomly generated (as the creation fails in case there already is a network with the given name). The alternative would be to reuse the existing network.


More information can be retrieved from #79

@erikengervall Let me know how you think bout this. 😊