### PR TITLE
feat: collect docker logs (and docker events)

### DIFF
--- a/packages/dockest/package.json
+++ b/packages/dockest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dockest",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.11",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [
@@ -33,7 +33,8 @@
   "dependencies": {
     "execa": "^2.0.4",
     "is-docker": "^2.0.0",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "rxjs": "^6.5.3"
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.1",

--- a/packages/dockest/src/constants.ts
+++ b/packages/dockest/src/constants.ts
@@ -73,6 +73,7 @@ export const INTERNAL_CONFIG = {
   isInsideDockerContainer: false,
   jestRanWithResult: false,
   perfStart: 0,
+  dockerLogs: [],
 }
 
 export const PROCESS_TEST_ENV = 'dockest-test'

--- a/packages/dockest/src/index.ts
+++ b/packages/dockest/src/index.ts
@@ -1,4 +1,5 @@
 import isDocker from 'is-docker' // eslint-disable-line import/default
+import { ExecaChildProcess } from 'execa'
 import { DEFAULT_USER_CONFIG, LOG_LEVEL, INTERNAL_CONFIG } from './constants'
 import { ErrorPayload, ObjStrStr, ArrayAtLeastOne } from './@types'
 import { JestConfig } from './onRun/runJest'
@@ -31,6 +32,8 @@ interface InternalConfig {
   isInsideDockerContainer: boolean
   jestRanWithResult: boolean
   perfStart: number
+  dockerLogs: string[]
+  dockerComposeUpProcess?: ExecaChildProcess
 }
 export interface DockestConfig {
   runners: ArrayAtLeastOne<Runner>

--- a/packages/dockest/src/onInstantiation/setupExitHandler.ts
+++ b/packages/dockest/src/onInstantiation/setupExitHandler.ts
@@ -6,7 +6,7 @@ import teardownSingle from '../utils/teardownSingle'
 
 export default async (config: DockestConfig): Promise<void> => {
   const {
-    $: { perfStart },
+    $: { perfStart, dockerLogs, dockerComposeUpProcess },
     opts: { exitHandler: customExitHandler },
     runners,
   } = config
@@ -32,6 +32,12 @@ export default async (config: DockestConfig): Promise<void> => {
     for (const runner of runners) {
       await teardownSingle(runner)
     }
+
+    if (dockerComposeUpProcess) {
+      await dockerComposeUpProcess.cancel()
+    }
+
+    Logger.error('Docker Container Logs: \n\n' + dockerLogs.join('\n'))
 
     if (config.opts.dumpErrors === true) {
       dumpError({

--- a/packages/dockest/src/onRun/createContainerStartCheck.ts
+++ b/packages/dockest/src/onRun/createContainerStartCheck.ts
@@ -1,0 +1,40 @@
+import { interval, Subject, race } from 'rxjs'
+import { takeUntil, tap, first, mapTo } from 'rxjs/operators'
+import { ServiceDockerEventStream } from './createServiceDockerEventStream'
+import { Runner } from '../runners/@types'
+
+export const createContainerStartCheck = (runner: Runner, eventStream$: ServiceDockerEventStream) => {
+  const stop$ = new Subject()
+
+  const cancel$ = new Subject()
+
+  const info$ = interval(1000).pipe(
+    takeUntil(stop$),
+    tap(() => {
+      runner.logger.info('Still waiting for start event...')
+    }),
+  )
+
+  const containerStarts$ = eventStream$.pipe(
+    takeUntil(stop$),
+    first(event => event.action === 'start'),
+  )
+
+  return {
+    service: runner.runnerConfig.service,
+    done: race(containerStarts$, info$, cancel$)
+      .pipe(
+        tap({
+          next: () => {
+            stop$.next()
+            stop$.complete()
+          },
+        }),
+        mapTo(undefined),
+      )
+      .toPromise(),
+    cancel: () => {
+      cancel$.complete()
+    },
+  }
+}

--- a/packages/dockest/src/onRun/createDockerEventEmitter.ts
+++ b/packages/dockest/src/onRun/createDockerEventEmitter.ts
@@ -1,0 +1,100 @@
+import EventEmitter from 'events'
+import execa from 'execa' /* eslint-disable-line import/default */
+import { GENERATED_COMPOSE_FILE_PATH } from '../constants'
+import { Runner } from '../runners/@types'
+
+const parseJsonSafe = (data: string) => {
+  try {
+    return JSON.parse(data)
+  } catch (err) {
+    return null
+  }
+}
+
+export interface DockerComposeEventInterface<TActionName extends string, TAdditionAtrributes extends {} = {}> {
+  time: string
+  type: 'container'
+  action: TActionName
+  id: string
+  service: string
+  attributes: {
+    image: string
+    name: string
+  } & TAdditionAtrributes
+}
+
+export type CreateDockerComposeEvent = DockerComposeEventInterface<'create'>
+export type AttachDockerComposeEvent = DockerComposeEventInterface<'attach'>
+export type StartDockerComposeEvent = DockerComposeEventInterface<'start'>
+export type HealthStatusDockerComposeEvent = DockerComposeEventInterface<
+  'health_status',
+  { healthStatus: 'healthy' | 'unhealthy' }
+>
+export type KillDockerComposeEvent = DockerComposeEventInterface<'kill'>
+export type DieDockerComposeEvent = DockerComposeEventInterface<'die'>
+
+export type DockerEventType =
+  | CreateDockerComposeEvent
+  | AttachDockerComposeEvent
+  | StartDockerComposeEvent
+  | HealthStatusDockerComposeEvent
+  | KillDockerComposeEvent
+  | DieDockerComposeEvent
+
+export type UnknownDockerComposeEvent = DockerComposeEventInterface<string>
+
+export type DockerEventEmitterListener = (event: DockerEventType) => void
+
+export interface DockerEventEmitter {
+  addListener(serviceName: string, eventListener: DockerEventEmitterListener): void
+  removeListener(serviceName: string, eventListener: DockerEventEmitterListener): void
+  destroy(): void
+}
+
+export const createDockerEventEmitter = (services: Array<Runner>): DockerEventEmitter => {
+  const command = ` \
+                docker-compose \
+                -f ${GENERATED_COMPOSE_FILE_PATH} \
+                events \
+                --json  \
+                ${services.map(service => service.runnerConfig.service).join(' ')}
+              `
+  const childProcess = execa(command, { shell: true, reject: false })
+
+  if (!childProcess.stdout) {
+    childProcess.kill()
+    throw new Error('Event Process has not output stream.')
+  }
+
+  const emitter = new EventEmitter()
+
+  // @TODO: without this line only the first data event is fired (in some undefinable cases)
+  childProcess.then(() => {})
+
+  childProcess.stdout.addListener('data', chunk => {
+    const lines = chunk
+      .toString()
+      .split(`\n`)
+      .filter(Boolean)
+
+    for (const line of lines) {
+      const data: UnknownDockerComposeEvent = parseJsonSafe(line)
+      if (!data) return
+
+      // convert health status to friendlier format
+      if (data.action.startsWith('health_status: ')) {
+        const healthStatus = data.action
+          .replace('health_status: ', '')
+          .trim() as HealthStatusDockerComposeEvent['attributes']['healthStatus']
+        data.action = 'health_status'
+        ;(data as HealthStatusDockerComposeEvent).attributes.healthStatus = healthStatus
+      }
+
+      emitter.emit(data.service, data)
+    }
+  })
+
+  return Object.assign(emitter, {
+    destroy: () => childProcess.cancel(),
+  })
+}

--- a/packages/dockest/src/onRun/createServiceDockerEventStream.ts
+++ b/packages/dockest/src/onRun/createServiceDockerEventStream.ts
@@ -1,0 +1,23 @@
+import { fromEventPattern, Observable } from 'rxjs'
+import { shareReplay } from 'rxjs/operators'
+import { DockerEventEmitter, DockerEventType } from './createDockerEventEmitter'
+
+export type ServiceDockerEventStream = Observable<DockerEventType>
+
+export const createServiceDockerEventStream = (
+  serviceName: string,
+  eventEmitter: DockerEventEmitter,
+): ServiceDockerEventStream => {
+  return (
+    fromEventPattern<DockerEventType>(
+      handler => {
+        eventEmitter.addListener(serviceName, handler)
+      },
+      handler => {
+        eventEmitter.removeListener(serviceName, handler)
+      },
+    )
+      // Every new subscriber should receive access to all previous emitted events, because of this we use shareReplay.
+      .pipe(shareReplay())
+  )
+}

--- a/packages/dockest/src/onRun/dockerComposeUp.ts
+++ b/packages/dockest/src/onRun/dockerComposeUp.ts
@@ -7,7 +7,7 @@ const dockerComposeUp = (serviceNames: string[]) => {
               -f ${`${GENERATED_COMPOSE_FILE_PATH}`} \
               up \
               --force-recreate \
-              --build \
+              --no-build \
               ${serviceNames.join(' ')} \
             `
 

--- a/packages/dockest/src/onRun/dockerComposeUp.ts
+++ b/packages/dockest/src/onRun/dockerComposeUp.ts
@@ -1,18 +1,17 @@
-import execaWrapper from '../utils/execaWrapper'
+import execa from 'execa' /* eslint-disable-line import/default */
 import { GENERATED_COMPOSE_FILE_PATH } from '../constants'
 
-const dockerComposeUp = async (serviceNames: string[]) => {
+const dockerComposeUp = (serviceNames: string[]) => {
   const command = ` \
               docker-compose \
               -f ${`${GENERATED_COMPOSE_FILE_PATH}`} \
               up \
               --force-recreate \
               --build \
-              --detach \
               ${serviceNames.join(' ')} \
             `
 
-  await execaWrapper(command)
+  return execa(command, { shell: true })
 }
 
 export default dockerComposeUp

--- a/yarn.lock
+++ b/yarn.lock
@@ -7723,7 +7723,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.2:
+rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.2, rxjs@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==


### PR DESCRIPTION
See #80

@n1ru4l [wrote](https://github.com/erikengervall/dockest/issues/80#issuecomment-538894071): 
>Instead of detaching the compose-up command (https://github.com/erikengervall/dockest/blob/master/src/onRun/dockerComposeUp.ts)
>
> we could keep it up as the log output will be written to stdout.
>
> That way we could collect the logs and add an option to write them to a file/output them to stdout in case something goes wrong e.g. container is exiting before a readiness check.
>
> Unhandled promise rejections are not addressed yet

____


~~tests are currently failing during to other changes which will hopefully be resolved by https://github.com/erikengervall/dockest/pull/97~~

~~Will rebase afterwards!~~

_____

Should also think about how we integration test dockest for correct behaviour when the tests fail.

