### PR TITLE
feat(dockest): expose dockest test helper under dockest/test-helper

### DIFF
--- a/packages/dockest/package.json
+++ b/packages/dockest/package.json
@@ -4,7 +4,8 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "test-helper/**/*"
   ],
   "description": "Dockest is an integration testing tool aimed at alleviating the process of evaluating unit tests whilst running multi-container Docker applications.",
   "keywords": [

--- a/packages/dockest/test-helper/package.json
+++ b/packages/dockest/test-helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dockest/test-helper",
+  "private": true,
+  "main": "../dist/test-helper",
+  "typings": "../dist/test-helper/index.d.ts"
+}

--- a/packages/examples/aws-codebuild/src/integration-test/hello-world.spec.ts
+++ b/packages/examples/aws-codebuild/src/integration-test/hello-world.spec.ts
@@ -1,6 +1,6 @@
 import http from 'http'
 import fetch from 'node-fetch'
-import { getHostAddress, getServiceAddress } from 'dockest/dist/test-helper'
+import { getHostAddress, getServiceAddress } from 'dockest/test-helper'
 
 const TARGET_HOST = getServiceAddress('aws_codebuild_website', 9000)
 


### PR DESCRIPTION
feat(dockest): expose dockest test helper under dockest/test-helper which is cleaner than importing them from dockest/dist/test-helper

I got this idea from here: https://github.com/cerebral/overmind/blob/next/packages/node_modules/overmind/config/package.json