### PR TITLE
fix: skip connection check in case there is no port exposed + map old port format to new format

### DIFF
--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -45,14 +45,19 @@ export interface RunnersObj {
   [key: string]: Runner
 }
 
+export type DockerComposePortStringFormat = string
+export type DockerComposePortObjectFormat = {
+  /** The publicly exposed port */
+  published: number
+  /** The port inside the container */
+  target: number
+}
+
+export type DockerComposePortFormat = DockerComposePortStringFormat | DockerComposePortObjectFormat
+
 export interface DockerComposeFileService {
   /** Expose ports */
-  ports: {
-    /** The publicly exposed port */
-    published: number
-    /** The port inside the container */
-    target: number
-  }[]
+  ports: DockerComposePortFormat[]
   [key: string]: any
 }
 

--- a/packages/dockest/src/run/waitForServices/checkConnection.ts
+++ b/packages/dockest/src/run/waitForServices/checkConnection.ts
@@ -3,6 +3,7 @@ import { race, of, from } from 'rxjs'
 import { concatMap, delay, ignoreElements, map, mergeMap, retryWhen, skipWhile, tap, takeWhile } from 'rxjs/operators'
 import { DockestError } from '../../Errors'
 import { Runner } from '../../@types'
+import { selectPortMapping } from '../../utils/selectPortMapping'
 
 export type AcquireConnectionFunctionType = ({ host, port }: { host: string; port: number }) => Promise<void>
 
@@ -96,7 +97,7 @@ export const createCheckConnection = ({
         throw new DockestError('Container unexpectedly died.', { event })
       }),
     ),
-    of(...ports).pipe(
+    of(...ports.map(selectPortMapping)).pipe(
       // concatMap -> run checks for each port in sequence
       concatMap(({ [portKey]: port }) => checkPortConnection({ runner, host, port, acquireConnection })),
       // we do not care about the single elements, we only want this stream to complete without errors.

--- a/packages/dockest/src/run/waitForServices/checkConnection.ts
+++ b/packages/dockest/src/run/waitForServices/checkConnection.ts
@@ -84,6 +84,10 @@ export const createCheckConnection = ({
 }) => {
   const host = runnerHost || 'localhost'
   const portKey = isBridgeNetworkMode ? 'target' : 'published'
+  if (!ports || ports.length === 0) {
+    runner.logger.debug(`${LOG_PREFIX} Skip connection check as there are no ports exposed.`)
+    return
+  }
 
   return race(
     dockerEventStream$.pipe(

--- a/packages/dockest/src/test-helper/index.ts
+++ b/packages/dockest/src/test-helper/index.ts
@@ -2,6 +2,7 @@ import isDocker from 'is-docker' // eslint-disable-line import/default
 import { DockerComposeFile } from '../@types'
 import { DOCKEST_ATTACH_TO_PROCESS, DOCKEST_HOST_ADDRESS, DEFAULT_HOST_NAME } from '../constants'
 import { DockestError } from '../Errors'
+import { selectPortMapping } from '../utils/selectPortMapping'
 
 const isInsideDockerContainer = isDocker()
 const dockestConfig = process.env[DOCKEST_ATTACH_TO_PROCESS]
@@ -26,7 +27,7 @@ export const getServiceAddress = (serviceName: string, targetPort: number | stri
     throw new DockestError(`Service "${serviceName}" does not exist`)
   }
 
-  const portBinding = service.ports.find(portBinding => portBinding.target === targetPort)
+  const portBinding = service.ports.map(selectPortMapping).find(portBinding => portBinding.target === targetPort)
   if (!portBinding) {
     throw new DockestError(`Service "${serviceName}" has no target port ${portBinding}`)
   }

--- a/packages/dockest/src/utils/createDefaultReadinessChecks.ts
+++ b/packages/dockest/src/utils/createDefaultReadinessChecks.ts
@@ -1,4 +1,5 @@
 import { execaWrapper } from './execaWrapper'
+import { selectPortMapping } from './selectPortMapping'
 import { DefaultReadinessChecks, Runner } from '../@types'
 
 export const createDefaultReadinessChecks = ({
@@ -25,7 +26,7 @@ export const createDefaultReadinessChecks = ({
   redis: async () => {
     const command = `docker exec ${containerId} redis-cli \
                         -h localhost \
-                        -p ${ports[0].target} \
+                        -p ${selectPortMapping(ports[0]).target} \
                         PING`
 
     await execaWrapper(command, { runner })

--- a/packages/dockest/src/utils/selectPortMapping.spec.ts
+++ b/packages/dockest/src/utils/selectPortMapping.spec.ts
@@ -1,0 +1,29 @@
+import { selectPortMapping } from './selectPortMapping'
+
+describe('selectPortMapping', () => {
+  it.each([
+    ['1234:1111', { target: 1111, published: 1234 }],
+    ['2222:1111', { target: 1111, published: 2222 }],
+    ['12:20', { target: 20, published: 12 }],
+    ['90:1000', { target: 1000, published: 90 }],
+  ])('can parse the string format', (input, expected) => {
+    expect(selectPortMapping(input)).toEqual(expected)
+  })
+
+  it.each([
+    [
+      { target: 1234, published: 1111 },
+      { target: 1234, published: 1111 },
+    ],
+    [
+      { target: 1111, published: 1234 },
+      { target: 1111, published: 1234 },
+    ],
+    [
+      { target: 3333, published: 3333 },
+      { target: 3333, published: 3333 },
+    ],
+  ])('passes through the object format', (input, expected) => {
+    expect(selectPortMapping(input)).toEqual(expected)
+  })
+})

--- a/packages/dockest/src/utils/selectPortMapping.ts
+++ b/packages/dockest/src/utils/selectPortMapping.ts
@@ -1,0 +1,7 @@
+import { DockerComposePortFormat } from '../@types'
+
+export const selectPortMapping = (input: DockerComposePortFormat) => {
+  if (typeof input !== 'string') return input
+  const [published, target] = input.split(':')
+  return { published: parseInt(published, 10), target: parseInt(target, 10) }
+}


### PR DESCRIPTION
Should probably also add an option that allows skipping the connection check.

Closes #155