### PR TITLE
feat: container log collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist
 docker-compose.dockest-generated.yml
 docker-compose.dockest-generated-runner.yml
 dockest-error.json
+dockest.log
 
 # Webstorm
 .idea/*

--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs'
 import { Logger } from './Logger'
 import { DockerEventEmitter } from './run/bootstrap/createDockerEventEmitter'
 import { DockerServiceEventStream } from './run/bootstrap/createDockerServiceEventStream'
+import { LogWriterModeType } from './run/log-writer'
 
 type ContainerId = string
 type ServiceName = string
@@ -78,6 +79,17 @@ export interface DockestOpts {
   skipCheckConnection: boolean
 
   jestLib: Jest
+
+  containerLogs: {
+    /** Method for gathering logs
+     * "per-service": One log file per service
+     * "aggregate": One log file for all services
+     * "pipe-stdout": Pipe logs to stdout
+     */
+    modes: LogWriterModeType[]
+    /** Only collect logs for the specified services. */
+    serviceNameFilter: string[]
+  }
 
   composeOpts: {
     /** Recreate dependent containers. Incompatible with --no-recreate. */

--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -89,6 +89,8 @@ export interface DockestOpts {
     modes: LogWriterModeType[]
     /** Only collect logs for the specified services. */
     serviceNameFilter: string[]
+    /** Where should the logs be written to? Defaults to "./" */
+    logPath: string
   }
 
   composeOpts: {

--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -88,7 +88,7 @@ export interface DockestOpts {
      */
     modes: LogWriterModeType[]
     /** Only collect logs for the specified services. */
-    serviceNameFilter: string[]
+    serviceNameFilter?: string[]
     /** Where should the logs be written to? Defaults to "./" */
     logPath: string
   }

--- a/packages/dockest/src/index.ts
+++ b/packages/dockest/src/index.ts
@@ -78,7 +78,7 @@ export class Dockest {
     })
     await debugMode({ debug, mutables })
     const { success } = await runJest({ jestLib, jestOpts, mutables })
-    await teardown({ hostname, runMode, mutables, perfStart })
+    await teardown({ hostname, runMode, mutables, perfStart, logWriter })
 
     success ? process.exit(0) : process.exit(1)
   }

--- a/packages/dockest/src/index.ts
+++ b/packages/dockest/src/index.ts
@@ -8,6 +8,7 @@ import { MINIMUM_JEST_VERSION } from './constants'
 import { runJest } from './run/runJest'
 import { teardown } from './run/teardown'
 import { waitForServices } from './run/waitForServices'
+import { createLogWriter } from './run/log-writer'
 
 export { execaWrapper as execa } from './utils/execaWrapper'
 export { LOG_LEVEL as logLevel } from './constants'
@@ -33,6 +34,11 @@ export class Dockest {
 
   public run = async (dockestServices: DockestService[]) => {
     this.config.perfStart = Date.now()
+
+    const logWriter = createLogWriter({
+      mode: ['aggregate', 'per-service'],
+      logPath: './',
+    })
 
     const {
       composeFile,
@@ -67,6 +73,7 @@ export class Dockest {
       runMode,
       runInBand,
       skipCheckConnection,
+      logWriter,
     })
     await debugMode({ debug, mutables })
     const { success } = await runJest({ jestLib, jestOpts, mutables })

--- a/packages/dockest/src/index.ts
+++ b/packages/dockest/src/index.ts
@@ -36,9 +36,9 @@ export class Dockest {
     this.config.perfStart = Date.now()
 
     const logWriter = createLogWriter({
-      mode: ['aggregate', 'per-service'],
+      mode: this.config.containerLogs.modes,
       serviceNameFilter: this.config.containerLogs.serviceNameFilter,
-      logPath: './',
+      logPath: this.config.containerLogs.logPath,
     })
 
     const {

--- a/packages/dockest/src/index.ts
+++ b/packages/dockest/src/index.ts
@@ -37,6 +37,7 @@ export class Dockest {
 
     const logWriter = createLogWriter({
       mode: ['aggregate', 'per-service'],
+      serviceNameFilter: this.config.containerLogs.serviceNameFilter,
       logPath: './',
     })
 

--- a/packages/dockest/src/run/log-writer.spec.ts
+++ b/packages/dockest/src/run/log-writer.spec.ts
@@ -1,0 +1,151 @@
+import { Readable, Writable } from 'stream'
+import { createLogWriter } from './log-writer'
+
+let writableMap: {
+  [name: string]: Writable
+}
+
+let resultMap: {
+  [name: string]: {
+    text: string
+  }
+}
+
+jest.mock('execa', () => {
+  return (command: string, args: Array<string>) => {
+    if (command !== 'docker-compose') {
+      fail('The mock is only expected to handle docker-compose execution.')
+    }
+
+    const serviceName = args.slice(0).pop() as string
+
+    const result = new Promise<void>(resolve => resolve())
+    const stdout = Readable.from([`mock text from ${serviceName}\n`])
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    result.stdout = stdout
+    return result
+  }
+})
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  createWriteStream: (name: string) => {
+    if (!writableMap[name]) {
+      writableMap[name] = new Writable({
+        write: (chunk, _, next) => {
+          if (!resultMap[name]) {
+            resultMap[name] = {
+              text: '',
+            }
+          }
+          resultMap[name].text += chunk.toString()
+          next()
+        },
+      })
+    }
+    return writableMap[name]
+  },
+}))
+
+// for the tests we mock the input and output in order to check whether stuff is forwarded correctly.
+beforeEach(() => {
+  writableMap = {}
+  resultMap = {}
+})
+
+test('it can be created', () => {
+  createLogWriter({
+    logPath: './',
+    mode: ['aggregate'],
+    serviceNameFilter: [],
+  })
+})
+
+test('can collect aggregated logs', async () => {
+  const writer = createLogWriter({
+    logPath: '.',
+    mode: ['aggregate'],
+  })
+
+  writer.register('foo', '1')
+  await new Promise(res => setImmediate(res))
+  expect(resultMap).toMatchInlineSnapshot(`
+    Object {
+      "dockest.log": Object {
+        "text": "mock text from foo
+    ",
+      },
+    }
+  `)
+})
+
+test('can collect individual logs', async () => {
+  const writer = createLogWriter({
+    logPath: '.',
+    mode: ['per-service'],
+  })
+
+  writer.register('foo', '1')
+  await new Promise(res => setImmediate(res))
+  expect(resultMap).toMatchInlineSnapshot(`
+    Object {
+      "foo.dockest.log": Object {
+        "text": "mock text from foo
+    ",
+      },
+    }
+  `)
+})
+
+test('can collect individual and aggregated logs', async () => {
+  const writer = createLogWriter({
+    logPath: '.',
+    mode: ['aggregate', 'per-service'],
+  })
+
+  writer.register('foo', '1')
+
+  await new Promise(res => setImmediate(res))
+  expect(resultMap).toMatchInlineSnapshot(`
+    Object {
+      "dockest.log": Object {
+        "text": "mock text from foo
+    ",
+      },
+      "foo.dockest.log": Object {
+        "text": "mock text from foo
+    ",
+      },
+    }
+  `)
+})
+
+test('can collect individual and aggregated logs from multiple services', async () => {
+  const writer = createLogWriter({
+    logPath: '.',
+    mode: ['aggregate', 'per-service'],
+  })
+
+  writer.register('foo', '1')
+  writer.register('bar', '2')
+
+  await new Promise(res => setImmediate(res))
+  expect(resultMap).toMatchInlineSnapshot(`
+    Object {
+      "bar.dockest.log": Object {
+        "text": "mock text from bar
+    ",
+      },
+      "dockest.log": Object {
+        "text": "mock text from foo
+    mock text from bar
+    ",
+      },
+      "foo.dockest.log": Object {
+        "text": "mock text from foo
+    ",
+      },
+    }
+  `)
+})

--- a/packages/dockest/src/run/log-writer.ts
+++ b/packages/dockest/src/run/log-writer.ts
@@ -16,11 +16,11 @@ export type LogWriter = {
 export const createLogWriter = ({
   mode,
   logPath,
-  serviceNameFilter = [],
+  serviceNameFilter,
 }: {
   mode: LogWriterModeType[]
   logPath: string
-  serviceNameFilter?: string[]
+  serviceNameFilter: string[]
 }) => {
   const writeStreamMap = new Map<string | symbol, WriteStream>()
 

--- a/packages/dockest/src/run/log-writer.ts
+++ b/packages/dockest/src/run/log-writer.ts
@@ -1,5 +1,4 @@
 import { createWriteStream, WriteStream } from 'fs'
-import { once } from 'events'
 import { join } from 'path'
 import execa from 'execa' /* eslint-disable-line import/default */
 import { DockestError } from '../Errors'
@@ -94,7 +93,6 @@ export const createLogWriter = ({
   const destroy = async () => {
     for (const stream of writeStreamMap.values()) {
       stream.end()
-      await once(stream, 'finish')
     }
   }
 

--- a/packages/dockest/src/run/log-writer.ts
+++ b/packages/dockest/src/run/log-writer.ts
@@ -1,0 +1,88 @@
+import { createWriteStream, WriteStream } from 'fs'
+import { join } from 'path'
+import execa from 'execa' /* eslint-disable-line import/default */
+import { DockestError } from '../Errors'
+import { Logger } from '../Logger'
+import { GENERATED_COMPOSE_FILE_PATH } from '../constants'
+
+export type LogWriterModeType = 'per-service' | 'aggregate' | 'pipe-stdout'
+
+const DEFAULT_LOG_SYMBOL = Symbol('DEFAULT_LOG')
+
+export type LogWriter = {
+  register: (serviceName: string, containerId: string) => void
+}
+
+export const createLogWriter = ({
+  mode,
+  logPath,
+  serviceNameFilter: filter,
+}: {
+  mode: LogWriterModeType[]
+  logPath: string
+  serviceNameFilter?: string
+}) => {
+  const writeStreamMap = new Map<string | symbol, WriteStream>()
+
+  if (mode.includes('aggregate')) {
+    const writeStream = createWriteStream(join(logPath, `dockest.log`))
+    writeStreamMap.set(DEFAULT_LOG_SYMBOL, writeStream)
+  }
+
+  const getDefaultWriteStream = () => {
+    const stream = writeStreamMap.get(DEFAULT_LOG_SYMBOL)
+    if (!stream) {
+      throw new DockestError('Could not find default log stream.')
+    }
+    return stream
+  }
+
+  const createOrGetFileStream = (serviceName: string) => {
+    let stream = writeStreamMap.get(serviceName)
+    if (!stream) {
+      stream = createWriteStream(join(logPath, `${serviceName}.dockest.log`))
+      writeStreamMap.set(serviceName, stream)
+    }
+    return stream
+  }
+
+  const getWriteStream = (serviceName: string) => {
+    if (mode.includes('aggregate')) {
+      return getDefaultWriteStream()
+    }
+    return createOrGetFileStream(serviceName)
+  }
+
+  const register = (serviceName: string, containerId: string) => {
+    if (filter && filter.includes(serviceName) === false) {
+      Logger.debug(`Skip log collection for service ${serviceName} with containerId: ${containerId}.`)
+      return
+    }
+
+    Logger.debug(`Registering log collection for ${serviceName} with containerId: ${containerId}`)
+
+    const logCollectionProcess = execa(`docker-compose`, [
+      '-f',
+      GENERATED_COMPOSE_FILE_PATH,
+      'logs',
+      '-f',
+      '--no-color',
+      serviceName,
+    ])
+    if (!logCollectionProcess.stdout) {
+      throw new DockestError('Process has no stdout.')
+    }
+    const writeStream = getWriteStream(serviceName)
+    if (mode.includes('pipe-stdout')) {
+      logCollectionProcess.stdout.pipe(process.stdout)
+    }
+    logCollectionProcess.stdout.pipe(writeStream)
+
+    // execa returns a lazy promise.
+    logCollectionProcess.then(() => undefined)
+  }
+
+  return {
+    register,
+  }
+}

--- a/packages/dockest/src/run/log-writer.ts
+++ b/packages/dockest/src/run/log-writer.ts
@@ -20,7 +20,7 @@ export const createLogWriter = ({
 }: {
   mode: LogWriterModeType[]
   logPath: string
-  serviceNameFilter: string[]
+  serviceNameFilter?: string[]
 }) => {
   const writeStreamMap = new Map<string | symbol, WriteStream>()
 
@@ -51,7 +51,7 @@ export const createLogWriter = ({
   }
 
   const register = (serviceName: string, containerId: string) => {
-    if (serviceNameFilter.includes(serviceName) === false) {
+    if (serviceNameFilter && serviceNameFilter.includes(serviceName) === false) {
       Logger.debug(`Skip log collection for service ${serviceName} with containerId: ${containerId}.`)
       return
     }

--- a/packages/dockest/src/run/teardown.ts
+++ b/packages/dockest/src/run/teardown.ts
@@ -1,3 +1,4 @@
+import { LogWriter } from './log-writer'
 import { DockestConfig } from '../@types'
 import { leaveBridgeNetwork } from '../utils/network/leaveBridgeNetwork'
 import { Logger } from '../Logger'
@@ -9,11 +10,13 @@ export const teardown = async ({
   runMode,
   mutables: { runners, dockerEventEmitter },
   perfStart,
+  logWriter,
 }: {
   hostname: DockestConfig['hostname']
   runMode: DockestConfig['runMode']
   mutables: DockestConfig['mutables']
   perfStart: DockestConfig['perfStart']
+  logWriter: LogWriter
 }) => {
   for (const runner of Object.values(runners)) {
     await teardownSingle({ runner })
@@ -25,6 +28,7 @@ export const teardown = async ({
   }
 
   dockerEventEmitter.destroy()
+  await logWriter.destroy()
 
   Logger.measurePerformance(perfStart)
 }

--- a/packages/dockest/src/run/waitForServices/index.spec.ts
+++ b/packages/dockest/src/run/waitForServices/index.spec.ts
@@ -29,6 +29,7 @@ const { composeOpts, hostname, runInBand } = getOpts()
 
 const mockLogWriter = {
   register: () => undefined,
+  destroy: () => Promise.resolve(),
 } as LogWriter
 
 describe('waitForServices', () => {

--- a/packages/dockest/src/run/waitForServices/index.spec.ts
+++ b/packages/dockest/src/run/waitForServices/index.spec.ts
@@ -12,6 +12,7 @@ import { bridgeNetworkExists } from '../../utils/network/bridgeNetworkExists'
 import { createBridgeNetwork } from '../../utils/network/createBridgeNetwork'
 import { createRunner } from '../../test-utils'
 import { getOpts } from '../../utils/getOpts'
+import { LogWriter } from '../log-writer'
 
 jest.mock('./checkConnection')
 jest.mock('./runReadinessCheck')
@@ -25,6 +26,10 @@ jest.mock('../../utils/network/bridgeNetworkExists')
 jest.mock('../../utils/network/createBridgeNetwork')
 
 const { composeOpts, hostname, runInBand } = getOpts()
+
+const mockLogWriter = {
+  register: () => undefined,
+} as LogWriter
 
 describe('waitForServices', () => {
   beforeEach(jest.resetAllMocks)
@@ -44,6 +49,7 @@ describe('waitForServices', () => {
         mutables: { runners, jestRanWithResult: false, dockerEventEmitter: new EventEmitter() as any },
         runInBand,
         skipCheckConnection: false,
+        logWriter: mockLogWriter,
       })
 
       expect(dockerComposeUp).toHaveBeenCalledTimes(3)
@@ -93,6 +99,7 @@ describe('waitForServices', () => {
         mutables: { runners, jestRanWithResult: false, dockerEventEmitter: new EventEmitter() as any },
         runInBand,
         skipCheckConnection: false,
+        logWriter: mockLogWriter,
       })
 
       // waitForRunner

--- a/packages/dockest/src/run/waitForServices/index.ts
+++ b/packages/dockest/src/run/waitForServices/index.ts
@@ -9,6 +9,7 @@ import { DOCKEST_HOST_ADDRESS } from '../../constants'
 import { DockestConfig, Runner } from '../../@types'
 import { joinBridgeNetwork } from '../../utils/network/joinBridgeNetwork'
 import { bridgeNetworkExists } from '../../utils/network/bridgeNetworkExists'
+import { LogWriter } from '../log-writer'
 
 const LOG_PREFIX = '[Setup]'
 
@@ -19,6 +20,7 @@ export const waitForServices = async ({
   mutables: { runners },
   runInBand,
   skipCheckConnection,
+  logWriter,
 }: {
   composeOpts: DockestConfig['composeOpts']
   hostname: DockestConfig['hostname']
@@ -26,6 +28,7 @@ export const waitForServices = async ({
   mutables: DockestConfig['mutables']
   runInBand: DockestConfig['runInBand']
   skipCheckConnection: DockestConfig['skipCheckConnection']
+  logWriter: LogWriter
 }) => {
   const setupPromises = []
 
@@ -39,6 +42,8 @@ export const waitForServices = async ({
 
     await dockerComposeUp({ composeOpts, serviceName })
     await resolveContainerId({ runner })
+
+    logWriter.register(runner.serviceName, runner.containerId)
 
     if (isBridgeNetworkMode) {
       await joinBridgeNetwork({ containerId: runner.containerId, alias: serviceName })

--- a/packages/dockest/src/utils/getOpts.spec.ts
+++ b/packages/dockest/src/utils/getOpts.spec.ts
@@ -20,6 +20,13 @@ describe('getOpts', () => {
           "noRecreate": false,
           "quietPull": false,
         },
+        "containerLogs": Object {
+          "logPath": "./",
+          "modes": Array [
+            "aggregate",
+          ],
+          "serviceNameFilter": Array [],
+        },
         "debug": false,
         "dumpErrors": false,
         "exitHandler": [Function],

--- a/packages/dockest/src/utils/getOpts.spec.ts
+++ b/packages/dockest/src/utils/getOpts.spec.ts
@@ -25,7 +25,7 @@ describe('getOpts', () => {
           "modes": Array [
             "aggregate",
           ],
-          "serviceNameFilter": Array [],
+          "serviceNameFilter": undefined,
         },
         "debug": false,
         "dumpErrors": false,

--- a/packages/dockest/src/utils/getOpts.ts
+++ b/packages/dockest/src/utils/getOpts.ts
@@ -25,7 +25,7 @@ export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
     jestOpts: { projects = ['.'], runInBand: runInBandJest = true } = {},
     logLevel = LOG_LEVEL.INFO,
     runInBand = true,
-    containerLogs: { serviceNameFilter = [], modes = ['aggregate', 'per-service'] as LogWriterModeType[] } = {},
+    containerLogs: { serviceNameFilter = [], modes = ['aggregate'] as LogWriterModeType[], logPath = './' } = {},
   } = opts
 
   return {
@@ -63,6 +63,7 @@ export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
     containerLogs: {
       modes,
       serviceNameFilter,
+      logPath,
     },
   }
 }

--- a/packages/dockest/src/utils/getOpts.ts
+++ b/packages/dockest/src/utils/getOpts.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import { getRunMode } from './getRunMode'
 import { DockestOpts, DockestConfig } from '../@types'
 import { LOG_LEVEL, DEFAULT_HOST_NAME } from '../constants'
+import { LogWriterModeType } from '../run/log-writer'
 
 export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
   const {
@@ -24,6 +25,7 @@ export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
     jestOpts: { projects = ['.'], runInBand: runInBandJest = true } = {},
     logLevel = LOG_LEVEL.INFO,
     runInBand = true,
+    containerLogs: { serviceNameFilter = [], modes = ['aggregate', 'per-service'] as LogWriterModeType[] } = {},
   } = opts
 
   return {
@@ -58,5 +60,9 @@ export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
     perfStart: Date.now(),
     runInBand,
     skipCheckConnection: false,
+    containerLogs: {
+      modes,
+      serviceNameFilter,
+    },
   }
 }

--- a/packages/dockest/src/utils/getOpts.ts
+++ b/packages/dockest/src/utils/getOpts.ts
@@ -25,7 +25,7 @@ export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
     jestOpts: { projects = ['.'], runInBand: runInBandJest = true } = {},
     logLevel = LOG_LEVEL.INFO,
     runInBand = true,
-    containerLogs: { serviceNameFilter = [], modes = ['aggregate'] as LogWriterModeType[], logPath = './' } = {},
+    containerLogs: { serviceNameFilter = undefined, modes = ['aggregate'] as LogWriterModeType[], logPath = './' } = {},
   } = opts
 
   return {

--- a/packages/examples/aws-codebuild/src/CI.Dockerfile
+++ b/packages/examples/aws-codebuild/src/CI.Dockerfile
@@ -7,7 +7,7 @@ ENV DOCKER_BUILD_X_VERSION="0.4.2"
 
 RUN apt-get update \
     && apt-get install -y python3 curl bash apt-transport-https ca-certificates software-properties-common gnupg2 jq \
-    && curl https://bootstrap.pypa.io/3.5/get-pip.py -o get-pip.py \
+    && curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py \
     && python3 get-pip.py \
     && rm get-pip.py \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \

--- a/packages/examples/aws-codebuild/src/CI.Dockerfile
+++ b/packages/examples/aws-codebuild/src/CI.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 
 LABEL author="Laurin Quast <laurinquast@googlemail.com>"
 

--- a/packages/examples/multiple-compose-files/postgres/app.spec.ts
+++ b/packages/examples/multiple-compose-files/postgres/app.spec.ts
@@ -7,11 +7,6 @@ const seedUser = {
   email: 'demo@demo.com',
 }
 
-beforeAll(async () => {
-  await execa('sequelize db:migrate:undo:all')
-  await execa('sequelize db:migrate')
-})
-
 beforeEach(async () => {
   await execa('sequelize db:seed:undo:all')
   await execa('sequelize db:seed:all')
@@ -26,9 +21,7 @@ describe('postgres-1-sequelize', () => {
 
   it('should be able to execute custom shell scripts', async () => {
     await execa('sequelize db:seed:undo:all')
-
     const { firstEntry } = await app()
-
     expect(firstEntry).toEqual(null)
   })
 })

--- a/packages/examples/multiple-resources/postgres-1-sequelize/app.spec.ts
+++ b/packages/examples/multiple-resources/postgres-1-sequelize/app.spec.ts
@@ -17,7 +17,6 @@ describe('postgres-1-sequelize', () => {
 
   it('should be able to execute custom shell scripts', async () => {
     await execa('sequelize db:seed:undo:all')
-
     const { firstEntry } = await app()
 
     expect(firstEntry).toEqual(null)

--- a/packages/examples/node-to-node/orders/index.js
+++ b/packages/examples/node-to-node/orders/index.js
@@ -22,6 +22,16 @@ app.get('/orders/:userId', (req, res) => {
   })
 })
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`${SERVICE_NAME} listening on port ${PORT}`) // eslint-disable-line no-console
+})
+
+process.on('SIGTERM', () => {
+  server.close(err => {
+    console.log('Shutting down.') // eslint-disable-line no-console
+    if (err) {
+      console.error(err) // eslint-disable-line no-console
+      process.exitCode = 1
+    }
+  })
 })

--- a/packages/examples/node-to-node/users/index.js
+++ b/packages/examples/node-to-node/users/index.js
@@ -46,6 +46,16 @@ app.get('/orders/:userId', async (req, res) => {
   return res.status(200).json(response.data)
 })
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`${SERVICE_NAME} listening on port ${PORT}`) // eslint-disable-line no-console
+})
+
+process.on('SIGTERM', () => {
+  server.close(err => {
+    console.log('Shutting down.') // eslint-disable-line no-console
+    if (err) {
+      console.error(err) // eslint-disable-line no-console
+      process.exitCode = 1
+    }
+  })
 })


### PR DESCRIPTION
Currently, I have the following in mind:

These are the log collection modes available:

`per-service`: Create one log file per service
`aggregate`: Create one log file that includes the logs of all services
`pipe-stdout`: Pipe log output to stdout of dockest process

When initializing the logWriter you can use one or multiple modes. E.g. you could pipe all the output to stdout but still pipe it into a file aswell.

The log writer also has a `serviceNameFilter` option for calming down the number of logs in a multi-container setup.

All the options for creating the log writer should be passed down via the dockest constructor, that way the user has the full power of handling logs.

@erikengervall Let me know how you think about this, then I polish it and add some tests ☺️

___________

Closes https://github.com/erikengervall/dockest/issues/80