### PR TITLE
fix: correctly handle services that have no ports defined

### DIFF
--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -40,7 +40,7 @@ export type DockerComposePortFormat = DockerComposePortStringFormat | DockerComp
 
 export interface DockerComposeFileService {
   /** Expose ports */
-  ports: DockerComposePortFormat[]
+  ports?: DockerComposePortFormat[]
   [key: string]: any
 }
 

--- a/packages/dockest/src/run/bootstrap/getParsedComposeFile.ts
+++ b/packages/dockest/src/run/bootstrap/getParsedComposeFile.ts
@@ -51,7 +51,7 @@ const PortBindingFromComposeFile = new io.Type(
   identity,
 )
 
-const DockerComposeService = io.type({
+const DockerComposeService = io.partial({
   ports: io.array(PortBindingFromComposeFile),
 })
 

--- a/packages/dockest/src/test-helper/index.ts
+++ b/packages/dockest/src/test-helper/index.ts
@@ -30,7 +30,7 @@ export const getHostAddress = () => {
 
 export const resolveServiceAddress = (serviceName: string, targetPort: number | string) => {
   const service = config.services[serviceName]
-  if (!service) {
+  if (!service || !service.ports) {
     throw new DockestError(`Service "${serviceName}" does not exist`)
   }
 


### PR DESCRIPTION
Tests on the master are currently filing because of this: https://github.com/erikengervall/dockest/pull/167/files#diff-cc4deae4c1c5e1c5a0708fc0b82dadab7b661fe99775a92008a0da455daa5ace