### PR TITLE
fix: readiness check should only fail preliminary when the event is a…

### DIFF
--- a/packages/dockest/src/run/bootstrap/createDockerEventEmitter.ts
+++ b/packages/dockest/src/run/bootstrap/createDockerEventEmitter.ts
@@ -29,7 +29,12 @@ export type HealthStatusDockerComposeEvent = DockerComposeEventInterface<
   { healthStatus: 'healthy' | 'unhealthy' }
 >
 export type KillDockerComposeEvent = DockerComposeEventInterface<'kill'>
-export type DieDockerComposeEvent = DockerComposeEventInterface<'die'>
+export type DieDockerComposeEvent = DockerComposeEventInterface<
+  'die',
+  {
+    exitCode: string
+  }
+>
 
 export type DockerEventType =
   | CreateDockerComposeEvent

--- a/packages/examples/aws-codebuild/src/CI.Dockerfile
+++ b/packages/examples/aws-codebuild/src/CI.Dockerfile
@@ -7,7 +7,7 @@ ENV DOCKER_BUILD_X_VERSION="0.4.2"
 
 RUN apt-get update \
     && apt-get install -y python3 curl bash apt-transport-https ca-certificates software-properties-common gnupg2 jq \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && curl https://bootstrap.pypa.io/3.5/get-pip.py -o get-pip.py \
     && python3 get-pip.py \
     && rm get-pip.py \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \


### PR DESCRIPTION
… kill event or the exit code is 0.

**NOTE: I CREATED https://github.com/erikengervall/dockest/pull/212 WHICH IS A BETTER SOLUTION BUT A BREAKING CHANGE**

I have one migration container whose readiness check goal is to exit with exit code 0.

```ts
import { filter, first, map } from "rxjs/operators";
import { race } from "rxjs";

const readinessCheck = deps => {
  return deps.dockerEventStream$
    .pipe(
      filter(
        ev => ev.service === "pg-migrations" && ev.action === "die"
      ),
      map(ev => {
        if (ev.attributes.exitCode !== "0") {
          throw new Error(
            "Container exited with the wrong exit code " +
              ev.attributes.exitCode
          );
        }
        return ev;
      }),
      first()
    )
    .toPromise();
};
```

However, the check will currently always fail as there is a "catch-all" handler for the "kill" and "die" event that will auto-fail all readiness checks. That behaviour is kind of preventing such stuff.

I would even go as far as completely removing that logic and instead have the user solve this in user-land.
The same applies to the retry logic. I think it would be better of exposing primitives for composing the retry of a readiness check.

```ts
import { retryReadinessCheck } from "dockest";

// create readiness check that is executed 10 times.
const readinessCheck = retryReadinessCheck(userLandReadinessCheck, 10);
```

In the case of listening to the docker event stream and depending on such type of events, it does not really make sense to retry. retry might make sense in a polling scenario (brute-forcing the SQL `SELECT 1` query until it succeeds), but not in a observing scenario (docker event stream, container logs etc.).
