### PR TITLE
feat: replace dependents with depends on

### DIFF
--- a/packages/dockest/package.json
+++ b/packages/dockest/package.json
@@ -43,12 +43,14 @@
     "io-ts": "^2.2.10",
     "is-docker": "^2.0.0",
     "js-yaml": "^3.13.1",
-    "rxjs": "^6.5.4"
+    "rxjs": "^6.5.4",
+    "toposort": "^2.0.2"
   },
   "devDependencies": {
     "@types/jest": "^24.9.1",
     "@types/js-yaml": "^3.12.2",
     "@types/node": "^13.5.0",
+    "@types/toposort": "^2.0.3",
     "jest": "^25.1.0",
     "mockdate": "^2.0.5",
     "ts-jest": "^25.3.0",

--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -14,7 +14,7 @@ export interface ReadinessCheck {
 export interface Runner {
   commands: Commands
   containerId: ContainerId
-  dependents: Runner[]
+  dependsOn: Runner[]
   dockerComposeFileService: DockerComposeFileService
   dockerEventStream$: DockerServiceEventStream
   logger: Logger
@@ -56,7 +56,7 @@ export type Commands = (string | ((containerId: string) => string))[]
 export interface DockestService {
   serviceName: ServiceName
   commands?: Commands
-  dependents?: DockestService[]
+  dependsOn?: DockestService[]
   readinessCheck?: ReadinessCheck
 }
 
@@ -65,6 +65,8 @@ export interface MutablesConfig {
   jestRanWithResult: boolean
   runners: RunnersObj
   dockerEventEmitter: DockerEventEmitter
+  runnerLookupMap: Map<string, Runner>
+  teardownOrder: null | Array<string>
 }
 
 type Jest = typeof import('jest')

--- a/packages/dockest/src/run/bootstrap/transformDockestServicesToRunners.spec.ts
+++ b/packages/dockest/src/run/bootstrap/transformDockestServicesToRunners.spec.ts
@@ -26,7 +26,7 @@ describe('transformDockestServicesToRunners', () => {
           "service1": Object {
             "commands": Array [],
             "containerId": "",
-            "dependents": Array [],
+            "dependsOn": Array [],
             "dockerComposeFileService": Object {
               "ports": Array [
                 Object {

--- a/packages/dockest/src/run/bootstrap/transformDockestServicesToRunners.ts
+++ b/packages/dockest/src/run/bootstrap/transformDockestServicesToRunners.ts
@@ -16,7 +16,7 @@ export const transformDockestServicesToRunners = ({
   dockerEventEmitter: DockerEventEmitter
 }) => {
   const createRunner = (dockestService: DockestService) => {
-    const { commands = [], dependents = [], readinessCheck = () => Promise.resolve(), serviceName } = dockestService
+    const { commands = [], dependsOn = [], readinessCheck = () => Promise.resolve(), serviceName } = dockestService
 
     const dockerComposeFileService = dockerComposeFile.services[serviceName]
     if (!dockerComposeFileService) {
@@ -28,7 +28,7 @@ export const transformDockestServicesToRunners = ({
     const runner: Runner = {
       commands,
       containerId: '',
-      dependents: dependents.map(createRunner),
+      dependsOn: dependsOn.map(createRunner),
       dockerComposeFileService,
       dockerEventStream$: createDockerServiceEventStream(serviceName, dockerEventEmitter),
       logger: new Logger(serviceName),

--- a/packages/dockest/src/run/waitForServices/index.spec.ts
+++ b/packages/dockest/src/run/waitForServices/index.spec.ts
@@ -36,7 +36,7 @@ describe('waitForServices', () => {
   beforeEach(jest.resetAllMocks)
 
   describe('happy', () => {
-    it('should call expected functions for runners without dependents', async () => {
+    it('should call expected functions for runners without dependsOn', async () => {
       const runners = {
         runner1: createRunner({ serviceName: 'runner1' }),
         runner2: createRunner({ serviceName: 'runner2' }),
@@ -47,7 +47,13 @@ describe('waitForServices', () => {
         composeOpts,
         hostname,
         runMode: 'host',
-        mutables: { runners, jestRanWithResult: false, dockerEventEmitter: new EventEmitter() as any },
+        mutables: {
+          runners,
+          jestRanWithResult: false,
+          dockerEventEmitter: new EventEmitter() as any,
+          runnerLookupMap: new Map(),
+          teardownOrder: null,
+        },
         runInBand,
         skipCheckConnection: false,
         logWriter: mockLogWriter,
@@ -80,24 +86,26 @@ describe('waitForServices', () => {
       expect(sleepWithLog).not.toHaveBeenCalled()
     })
 
-    it('should call expected functions for runners with dependents', async () => {
+    it('should call expected functions for runners with dependsOn', async () => {
+      const runner3 = createRunner({ serviceName: 'runner3' })
+      const runner2 = createRunner({ serviceName: 'runner2' })
+      const runner1 = createRunner({ serviceName: 'runner1', dependsOn: [runner2] })
       const runners = {
-        runner1: createRunner({
-          serviceName: 'runner1',
-          dependents: [
-            createRunner({
-              serviceName: 'runner2',
-            }),
-          ],
-        }),
-        runner3: createRunner({ serviceName: 'runner3' }),
+        runner1: runner1,
+        runner3: runner3,
       }
 
       await waitForServices({
         composeOpts,
         hostname,
         runMode: 'host',
-        mutables: { runners, jestRanWithResult: false, dockerEventEmitter: new EventEmitter() as any },
+        mutables: {
+          runners,
+          jestRanWithResult: false,
+          dockerEventEmitter: new EventEmitter() as any,
+          runnerLookupMap: new Map(),
+          teardownOrder: null,
+        },
         runInBand,
         skipCheckConnection: false,
         logWriter: mockLogWriter,

--- a/packages/dockest/src/run/waitForServices/index.ts
+++ b/packages/dockest/src/run/waitForServices/index.ts
@@ -1,3 +1,4 @@
+import toposort from 'toposort'
 import { checkConnection } from './checkConnection'
 import { runReadinessCheck } from './runReadinessCheck'
 import { dockerComposeUp } from './dockerComposeUp'
@@ -10,6 +11,7 @@ import { DockestConfig, Runner } from '../../@types'
 import { joinBridgeNetwork } from '../../utils/network/joinBridgeNetwork'
 import { bridgeNetworkExists } from '../../utils/network/bridgeNetworkExists'
 import { LogWriter } from '../log-writer'
+import { DockestError } from '../../Errors'
 
 const LOG_PREFIX = '[Setup]'
 
@@ -17,7 +19,7 @@ export const waitForServices = async ({
   composeOpts,
   hostname,
   runMode,
-  mutables: { runners },
+  mutables,
   runInBand,
   skipCheckConnection,
   logWriter,
@@ -30,14 +32,7 @@ export const waitForServices = async ({
   skipCheckConnection: DockestConfig['skipCheckConnection']
   logWriter: LogWriter
 }) => {
-  const setupPromises = []
-
-  const waitForRunner = async ({
-    runner,
-    runner: { isBridgeNetworkMode, dependents, serviceName },
-  }: {
-    runner: Runner
-  }) => {
+  const waitForRunner = async ({ runner, runner: { isBridgeNetworkMode, serviceName } }: { runner: Runner }) => {
     runner.logger.debug(`${LOG_PREFIX} Initiating...`)
 
     await dockerComposeUp({ composeOpts, serviceName })
@@ -62,10 +57,6 @@ export const waitForServices = async ({
     await runRunnerCommands({ runner })
 
     runner.logger.info(`${LOG_PREFIX} Success`, { success: true, endingNewLines: 1 })
-
-    for (const dependant of dependents) {
-      await waitForRunner({ runner: dependant })
-    }
   }
 
   if (runMode === 'docker-injected-host-socket') {
@@ -76,13 +67,42 @@ export const waitForServices = async ({
     await joinBridgeNetwork({ containerId: hostname, alias: DOCKEST_HOST_ADDRESS })
   }
 
-  for (const runner of Object.values(runners)) {
-    if (runInBand) {
-      await waitForRunner({ runner })
+  const dependencyGraph: Array<[string, string | undefined]> = []
+
+  const walkRunner = (runner: Runner) => {
+    if (mutables.runnerLookupMap.has(runner.serviceName)) {
+      return
+    }
+    mutables.runnerLookupMap.set(runner.serviceName, runner)
+
+    if (runner.dependsOn.length === 0) {
+      dependencyGraph.push([runner.serviceName, undefined])
     } else {
-      setupPromises.push(waitForRunner({ runner }))
+      for (const dependencyRunner of runner.dependsOn) {
+        dependencyGraph.push([dependencyRunner.serviceName, runner.serviceName])
+        walkRunner(dependencyRunner)
+      }
     }
   }
 
-  await Promise.all(setupPromises)
+  for (const runner of Object.values(mutables.runners)) {
+    walkRunner(runner)
+  }
+
+  if (runInBand) {
+    const ordered: Array<string> = toposort(dependencyGraph).filter(value => value !== undefined)
+
+    const teardownOrder = ordered.slice(0).reverse()
+    mutables.teardownOrder = teardownOrder
+
+    for (const serviceName of ordered) {
+      const runner = mutables.runnerLookupMap.get(serviceName)
+      if (!runner) {
+        throw new DockestError('Unexpected error. Runner could not be found.')
+      }
+      await waitForRunner({ runner })
+    }
+  } else {
+    await Promise.all(Array.from(mutables.runnerLookupMap.values()).map(runner => waitForRunner({ runner })))
+  }
 }

--- a/packages/dockest/src/test-utils.ts
+++ b/packages/dockest/src/test-utils.ts
@@ -5,7 +5,7 @@ import { Logger } from './Logger'
 export const createRunner = (overrides?: Partial<Runner>): Runner => ({
   commands: [],
   containerId: '',
-  dependents: [],
+  dependsOn: [],
   dockerComposeFileService: { image: 'node:10-alpine', ports: [{ published: 3000, target: 3000 }] },
   dockerEventStream$: new ReplaySubject(),
   logger: new Logger('node'),

--- a/packages/dockest/src/utils/getOpts.ts
+++ b/packages/dockest/src/utils/getOpts.ts
@@ -47,6 +47,8 @@ export const getOpts = (opts: Partial<DockestOpts> = {}): DockestConfig => {
       jestRanWithResult: false,
       runners: {},
       dockerEventEmitter: new EventEmitter() as any,
+      teardownOrder: null,
+      runnerLookupMap: new Map(),
     },
     hostname: process.env.HOSTNAME || DEFAULT_HOST_NAME,
     runMode: getRunMode(),

--- a/packages/dockest/src/utils/teardownSingle.ts
+++ b/packages/dockest/src/utils/teardownSingle.ts
@@ -14,18 +14,9 @@ const removeContainerById = async ({ runner, runner: { containerId } }: { runner
   await execaWrapper(command, { runner, logPrefix: '[Remove Container]', logStdout: true })
 }
 
-export const teardownSingle = async ({
-  runner,
-  runner: { containerId, dependents, serviceName },
-}: {
-  runner: Runner
-}) => {
+export const teardownSingle = async ({ runner, runner: { containerId, serviceName } }: { runner: Runner }) => {
   if (!containerId) {
     throw new DockestError(`Invalid containerId (${containerId}) for service (${serviceName})`, { runner })
-  }
-
-  for (const dependant of dependents) {
-    await teardownSingle({ runner: dependant })
   }
 
   await stopContainerById({ runner })

--- a/packages/dockest/yarn.lock
+++ b/packages/dockest/yarn.lock
@@ -421,6 +421,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/toposort@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/toposort/-/toposort-2.0.3.tgz#dc490842b77c3e910c8d727ff0bdb2fb124cb41b"
+  integrity sha512-jRtyvEu0Na/sy0oIxBW0f6wPQjidgVqlmCTJVHEGTNEUdL1f0YSvdPzHY7nX7MUWAZS6zcAa0KkqofHjy/xDZQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -3232,6 +3237,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 tough-cookie@^2.3.3:
   version "2.5.0"

--- a/packages/examples/multiple-resources/dockest.ts
+++ b/packages/examples/multiple-resources/dockest.ts
@@ -39,13 +39,13 @@ run([
   },
 
   {
-    serviceName: 'multiple_resources_zookeeper',
-    dependents: [
+    // https://github.com/wurstmeister/kafka-docker/issues/167
+    serviceName: 'multiple_resources_kafka',
+    dependsOn: [
       {
-        // https://github.com/wurstmeister/kafka-docker/issues/167
-        serviceName: 'multiple_resources_kafka',
-        readinessCheck: () => sleepWithLog(10, `Sleeping a bit for Kafka's sake`),
+        serviceName: 'multiple_resources_zookeeper',
       },
     ],
+    readinessCheck: () => sleepWithLog(10, `Sleeping a bit for Kafka's sake`),
   },
 ])

--- a/packages/examples/node-to-node/dockest.ts
+++ b/packages/examples/node-to-node/dockest.ts
@@ -11,7 +11,7 @@ run([
   {
     serviceName: 'node_to_node_orders',
     commands: ['echo "Hello from orders (dependency - should run first) 👋🏽"'],
-    dependents: [
+    dependsOn: [
       {
         serviceName: 'node_to_node_users',
         commands: ['echo "Hello from users (dependent - should run right after orders) 👋🏽"'],

--- a/website/versioned_docs/version-3.0.0/api_reference_run.md
+++ b/website/versioned_docs/version-3.0.0/api_reference_run.md
@@ -14,7 +14,7 @@ const dockestServices = [
   {
     serviceName: 'service1',
     commands: ['echo "Hello name1 🌊"'],
-    dependents: [
+    dependsOn: [
       {
         serviceName: 'service2',
       },
@@ -36,7 +36,7 @@ Dockest services are meant to map to services declared in the Compose file(s)
 | ----------------------------------------------- | -------------------------------------------------- | ------------------------- |
 | **[name](#dockestservicename)**                 | `string`                                           | property is required      |
 | [commands](#dockestservicecommands)             | <code>(string &#124; function)[] => string[]<code> | `[]`                      |
-| [dependents](#dockestservicedependents)         | `DockestService[]`                                 | `[]`                      |
+| [dependsOn](#dockestservicedependson)           | `DockestService[]`                                 | `[]`                      |
 | [readinessCheck](#dockestservicereadinesscheck) | `function`                                         | `() => Promise.resolve()` |
 
 ## `DockestService.name`
@@ -49,9 +49,9 @@ Bash scripts that will run once the service is ready. E.g. database migrations.
 
 Can either be a string, or a function that generates a string. The function is fed the container id of the service.
 
-## `DockestService.dependents`
+## `DockestService.dependsOn`
 
-`dependents` are Dockest services that are are dependent on the parent service.
+With the `dependsOn` options you specify other services this service relies on.
 
 For example, the following code
 
@@ -59,7 +59,7 @@ For example, the following code
 const dockestServices = [
   {
     serviceName: 'service1',
-    dependents: [
+    dependsOn: [
       {
         serviceName: 'service2',
       },
@@ -68,7 +68,7 @@ const dockestServices = [
 ]
 ```
 
-will ensure that `service1` starts up and is fully responsive before even attempting to start `service2`.
+will ensure that `service2` starts up and is fully responsive before even attempting to start `service1`.
 
 > Why not rely on the Docker File service configuration options `depends_on`?
 


### PR DESCRIPTION
The `dependents` option is quite cumbersome as in practice it is easier to declare on which services a service is depending on instead of the other way around. This pr replaces the `dependents` option with a `dependsOn` option. The service dependencies are then resolved into a list that respects the run order of each service and its dependencies. Cyclic dependencies result in an error. If your projects have cyclic dependencies between containers the containers should not rely on startup order but instead handle the absence of the other container in their business logic.

I choose toposort because it already had ts typings. But there is also https://github.com/glebec/batching-toposort which can also generate lists of steps that can be executed in parallel instead of only acting in sequence.