### PR TITLE
Allow published binding port to be string

### DIFF
--- a/packages/dockest/src/@types.ts
+++ b/packages/dockest/src/@types.ts
@@ -30,8 +30,8 @@ export interface RunnersObj {
 
 export type DockerComposePortStringFormat = string
 export type DockerComposePortObjectFormat = {
-  /** The publicly exposed port */
-  published: number
+  /** The publicly exposed port. Became a string after docker compose version 2.3.3 */
+  published: number | string
   /** The port inside the container */
   target: number
 }

--- a/packages/dockest/src/run/bootstrap/getParsedComposeFile.spec.ts
+++ b/packages/dockest/src/run/bootstrap/getParsedComposeFile.spec.ts
@@ -1,8 +1,8 @@
 import { getParsedComposeFile } from './getParsedComposeFile'
-import { MERGED_COMPOSE_FILES } from '../../test-utils'
+import { MERGED_COMPOSE_FILES, MERGED_COMPOSE_FILES_VERSION_2_3_3_PLUS } from '../../test-utils'
 
 describe('getParsedComposeFile', () => {
-  describe('happy', () => {
+  describe('with published ports as number', () => {
     it('should work', () => {
       const { dockerComposeFile } = getParsedComposeFile(MERGED_COMPOSE_FILES)
 
@@ -20,6 +20,29 @@ describe('getParsedComposeFile', () => {
             },
           },
           "version": "3.8",
+        }
+      `)
+    })
+  })
+
+  describe('with published ports as string', () => {
+    it('should work', () => {
+      const { dockerComposeFile } = getParsedComposeFile(MERGED_COMPOSE_FILES_VERSION_2_3_3_PLUS)
+
+      expect(dockerComposeFile).toMatchInlineSnapshot(`
+        Object {
+          "name": "application",
+          "services": Object {
+            "redis": Object {
+              "image": "redis:5.0.3-alpine",
+              "ports": Array [
+                Object {
+                  "published": "6379",
+                  "target": 6379,
+                },
+              ],
+            },
+          },
         }
       `)
     })

--- a/packages/dockest/src/run/bootstrap/getParsedComposeFile.ts
+++ b/packages/dockest/src/run/bootstrap/getParsedComposeFile.ts
@@ -6,7 +6,7 @@ import { pipe, identity, flow } from 'fp-ts/lib/function'
 import { DockestError } from '../../Errors'
 
 const PortBinding = io.type({
-  published: io.number,
+  published: io.union([io.number, io.string]),
   target: io.number,
 })
 

--- a/packages/dockest/src/test-utils.ts
+++ b/packages/dockest/src/test-utils.ts
@@ -42,3 +42,13 @@ services:
       target: 6379
 version: '3.8'
 `
+
+export const MERGED_COMPOSE_FILES_VERSION_2_3_3_PLUS = `
+name: application
+services:
+  redis:
+    image: redis:5.0.3-alpine
+    ports:
+    - published: '6379'
+      target: 6379
+`


### PR DESCRIPTION
Since docker compose version 2.3.x, the default behavior now is to return the published binding port as string, which breaks the dockest validation.

This PR fixes the issue #300 

https://github.com/docker/compose/issues/9306